### PR TITLE
Windows support: blockers to compile (#2-#5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/crates/phantom-cli/Cargo.toml
+++ b/crates/phantom-cli/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { workspace = true }
 zeroize = { workspace = true }
 libc = "0.2"
 open = "5"
+which = "6"
 indicatif = "0.17"
 base64 = { workspace = true }
 notify = "7"

--- a/crates/phantom-cli/Cargo.toml
+++ b/crates/phantom-cli/Cargo.toml
@@ -21,7 +21,6 @@ tracing-subscriber = { workspace = true }
 colored = "2"
 serde_json = { workspace = true }
 zeroize = { workspace = true }
-libc = "0.2"
 open = "5"
 which = "6"
 indicatif = "0.17"

--- a/crates/phantom-cli/src/commands/reveal.rs
+++ b/crates/phantom-cli/src/commands/reveal.rs
@@ -19,17 +19,12 @@ pub fn run(name: &str, clipboard: bool, yes: bool) -> Result<()> {
     // Safety gate: refuse to reveal in non-interactive contexts unless --yes is passed.
     // This prevents AI agents from calling `phantom reveal` to extract real secrets.
     if !yes {
-        // Check if stdout is a TTY (interactive terminal)
-        #[cfg(unix)]
-        {
-            use std::os::unix::io::AsRawFd;
-            let is_tty = unsafe { libc::isatty(std::io::stdout().as_raw_fd()) } != 0;
-            if !is_tty {
-                anyhow::bail!(
-                    "Refusing to reveal secret in non-interactive context.\n\
-                     Pass --yes to override. This prevents AI agents from extracting secrets."
-                );
-            }
+        use std::io::IsTerminal;
+        if !std::io::stdout().is_terminal() {
+            anyhow::bail!(
+                "Refusing to reveal secret in non-interactive context.\n\
+                 Pass --yes to override. This prevents AI agents from extracting secrets."
+            );
         }
 
         eprintln!(

--- a/crates/phantom-cli/src/commands/setup.rs
+++ b/crates/phantom-cli/src/commands/setup.rs
@@ -162,13 +162,7 @@ fn find_mcp_binary() -> Option<String> {
 
     for candidate in candidates.into_iter().flatten() {
         if candidate == "phantom-mcp" {
-            // Check if it's in PATH
-            if std::process::Command::new("which")
-                .arg("phantom-mcp")
-                .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false)
-            {
+            if which::which("phantom-mcp").is_ok() {
                 return Some(candidate);
             }
         } else if Path::new(&candidate).exists() {

--- a/crates/phantom-cli/src/commands/stop.rs
+++ b/crates/phantom-cli/src/commands/stop.rs
@@ -15,11 +15,17 @@ pub fn run() -> Result<()> {
 
     if let Some(pid_str) = parts.first() {
         if let Ok(pid) = pid_str.parse::<u32>() {
-            // Send SIGTERM to the proxy process
+            // Send stop signal to the proxy process
             #[cfg(unix)]
             {
                 let _ = std::process::Command::new("kill")
                     .arg(pid.to_string())
+                    .status();
+            }
+            #[cfg(windows)]
+            {
+                let _ = std::process::Command::new("taskkill")
+                    .args(["/PID", &pid.to_string(), "/F"])
                     .status();
             }
             println!(

--- a/crates/phantom-core/Cargo.toml
+++ b/crates/phantom-core/Cargo.toml
@@ -15,7 +15,7 @@ zeroize = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
 base64 = { workspace = true }
-keyring = { version = "3", features = ["apple-native", "linux-native"] }
+keyring = { version = "3", features = ["apple-native", "linux-native", "windows-native"] }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/crates/phantom-vault/Cargo.toml
+++ b/crates/phantom-vault/Cargo.toml
@@ -11,7 +11,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 zeroize = { workspace = true }
-keyring = { version = "3", features = ["apple-native", "linux-native"] }
+keyring = { version = "3", features = ["apple-native", "linux-native", "windows-native"] }
 directories = "5"
 rand = { workspace = true }
 hex = { workspace = true }


### PR DESCRIPTION
First slice of #1 (Windows support).

## Summary
- Adds `windows-native` feature to keyring (#2)
- Replaces `which` shell-out with the `which` crate (#3)
- Adds `taskkill` path for `phantom stop` (#4)
- Swaps `libc::isatty` for `std::io::IsTerminal` — also fixes a latent bug where the non-interactive guard on `phantom reveal` was silently skipped on Windows (#5)
- Drops now-unused `libc` dep from `phantom-cli`
- Adds `windows-latest` to CI matrix (partial #11)

All changes are additive; Unix code paths are gated `cfg(unix)` and unchanged in behavior.

## Test plan
- [ ] CI green on `ubuntu-latest`
- [ ] CI green on `macos-latest`
- [ ] CI green on `windows-latest` — the whole point
- [ ] Manual `cargo test` pass locally (blocked by Smart App Control on the dev machine; relying on CI)

Closes #2, #3, #4, #5