### PR TITLE
Windows: cross-platform home_dir lookup (#8, #13)

### DIFF
--- a/crates/phantom-cli/Cargo.toml
+++ b/crates/phantom-cli/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { workspace = true }
 zeroize = { workspace = true }
 open = "5"
 which = "6"
+dirs = "5"
 indicatif = "0.17"
 base64 = { workspace = true }
 notify = "7"

--- a/crates/phantom-cli/src/commands/setup.rs
+++ b/crates/phantom-cli/src/commands/setup.rs
@@ -174,5 +174,5 @@ fn find_mcp_binary() -> Option<String> {
 }
 
 fn dirs_home() -> Option<String> {
-    std::env::var("HOME").ok()
+    dirs::home_dir().map(|p| p.to_string_lossy().into_owned())
 }

--- a/crates/phantom-vault/Cargo.toml
+++ b/crates/phantom-vault/Cargo.toml
@@ -13,6 +13,7 @@ thiserror = { workspace = true }
 zeroize = { workspace = true }
 keyring = { version = "3", features = ["apple-native", "linux-native", "windows-native"] }
 directories = "5"
+dirs = "5"
 rand = { workspace = true }
 hex = { workspace = true }
 

--- a/crates/phantom-vault/src/lib.rs
+++ b/crates/phantom-vault/src/lib.rs
@@ -69,6 +69,6 @@ fn generate_passphrase() -> String {
 }
 
 fn dirs_fallback() -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    std::path::PathBuf::from(home).join(".phantom")
+    let home = dirs::home_dir().unwrap_or_else(std::env::temp_dir);
+    home.join(".phantom")
 }


### PR DESCRIPTION
Second slice of #1 (Windows support) — Tier 1 (home dir).

## Summary
Replaces direct reads of `\$HOME` with `dirs::home_dir()`, which resolves to `\$HOME` on Unix and `%USERPROFILE%` on Windows.

- **Vault fallback path** (`crates/phantom-vault/src/lib.rs:71-74`) — keeps the existing `~/.phantom` vault location on all OSes (behavior-preserving for existing Mac/Linux users; correct on Windows). `/tmp` fallback replaced with `std::env::temp_dir()` which resolves to `%TEMP%` on Windows.
- **Setup helper** (`crates/phantom-cli/src/commands/setup.rs:176-178`) — used to locate `~/.cargo/bin/phantom-mcp`.

## Why no vault migration concern
The `dirs_fallback()` path is already `$HOME/.phantom` on Unix. `dirs::home_dir()` returns the same `$HOME` value on Unix. Existing vaults keep the same location.

## Test plan
- [ ] CI green on `ubuntu-latest`
- [ ] CI green on `macos-latest`
- [ ] CI green on `windows-latest`

Closes #8
Closes #13