### PR TITLE
Windows: cross-platform clipboard + daemon spawn (#6, #7)

### DIFF
--- a/crates/phantom-cli/Cargo.toml
+++ b/crates/phantom-cli/Cargo.toml
@@ -24,6 +24,7 @@ zeroize = { workspace = true }
 open = "5"
 which = "6"
 dirs = "5"
+arboard = { version = "3", default-features = false }
 indicatif = "0.17"
 base64 = { workspace = true }
 notify = "7"

--- a/crates/phantom-cli/src/commands/reveal.rs
+++ b/crates/phantom-cli/src/commands/reveal.rs
@@ -74,38 +74,8 @@ pub fn run(name: &str, clipboard: bool, yes: bool) -> Result<()> {
 }
 
 fn copy_to_clipboard(text: &str) -> bool {
-    #[cfg(target_os = "macos")]
-    {
-        use std::io::Write;
-        if let Ok(mut child) = std::process::Command::new("pbcopy")
-            .stdin(std::process::Stdio::piped())
-            .spawn()
-        {
-            if let Some(stdin) = child.stdin.as_mut() {
-                let _ = stdin.write_all(text.as_bytes());
-            }
-            return child.wait().map(|s| s.success()).unwrap_or(false);
-        }
+    match arboard::Clipboard::new() {
+        Ok(mut clipboard) => clipboard.set_text(text.to_string()).is_ok(),
+        Err(_) => false,
     }
-
-    #[cfg(target_os = "linux")]
-    {
-        use std::io::Write;
-        for cmd in &["xclip", "xsel"] {
-            if let Ok(mut child) = std::process::Command::new(cmd)
-                .args(["-selection", "clipboard"])
-                .stdin(std::process::Stdio::piped())
-                .spawn()
-            {
-                if let Some(stdin) = child.stdin.as_mut() {
-                    let _ = stdin.write_all(text.as_bytes());
-                }
-                if child.wait().map(|s| s.success()).unwrap_or(false) {
-                    return true;
-                }
-            }
-        }
-    }
-
-    false
 }

--- a/crates/phantom-cli/src/commands/start.rs
+++ b/crates/phantom-cli/src/commands/start.rs
@@ -49,11 +49,18 @@ fn run_daemon() -> Result<()> {
         .stderr(Stdio::null())
         .stdin(Stdio::null());
 
-    // On Unix, start a new session so the child survives the parent exiting.
+    // Detach the child so it survives the parent exiting.
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
         cmd.process_group(0);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const DETACHED_PROCESS: u32 = 0x00000008;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        cmd.creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW);
     }
 
     cmd.spawn()


### PR DESCRIPTION
Third slice of #1 (Windows support) — Tier 2A.

## Summary

- **Clipboard (#6):** Replaces three platform-specific shell-outs (pbcopy/xclip/xsel) with a single `arboard::Clipboard` call. Adds Windows clipboard support as a side-effect — previously \`phantom reveal --copy\` failed on Windows and fell back to stdout.
- **Daemon (#7):** Adds \`cfg(windows)\` branch to \`phantom start --daemon\` using \`CommandExt::creation_flags\` with \`DETACHED_PROCESS | CREATE_NO_WINDOW\`. Unix behavior unchanged.

## Deliberate scope

- **#9 (cross-platform auto-clear) deferred.** The 30-second clipboard auto-clear remains macOS-only via the existing \`bash -c "sleep && pbcopy"\` hack. Closing #9 properly needs a detached-process design (a \`thread::spawn\` thread dies with the parent), which is a larger change — reopening #9 with that context as a focused follow-up.
- **Windows ACL on PID file.** The existing \`cfg(unix)\` block setting \`0o600\` on the PID file stays Unix-only. A Windows ACL equivalent is a separate follow-up if needed — the PID file lives inside the project dir, so exposure is limited to the local user.

## Test plan
- [ ] CI green on \`ubuntu-latest\` (watching for arboard linker issues — may need \`libxcb*-dev\`)
- [ ] CI green on \`macos-latest\`
- [ ] CI green on \`windows-latest\`

Closes #6
Closes #7