### PR TITLE
npm: unblock Windows install path in wrapper (#15)

### DIFF
--- a/npm/bin/cli.js
+++ b/npm/bin/cli.js
@@ -26,6 +26,8 @@ function getPlatformTarget() {
     return "x86_64-unknown-linux-gnu";
   if (platform === "linux" && arch === "arm64")
     return "aarch64-unknown-linux-gnu";
+  if (platform === "win32" && arch === "x64")
+    return "x86_64-pc-windows-msvc";
 
   console.error(
     `Unsupported platform: ${platform}-${arch}. Install from source: cargo install phantom --git https://github.com/${REPO}`
@@ -63,24 +65,35 @@ async function ensureBinary() {
   }
 
   const target = getPlatformTarget();
-  const tarball = `phantom-${target}.tar.gz`;
-  const url = `https://github.com/${REPO}/releases/download/v${VERSION}/${tarball}`;
+  const isWindows = process.platform === "win32";
+  const archiveExt = isWindows ? "zip" : "tar.gz";
+  const archiveName = `phantom-${target}.${archiveExt}`;
+  const url = `https://github.com/${REPO}/releases/download/v${VERSION}/${archiveName}`;
 
   console.error(`Downloading phantom v${VERSION} for ${target}...`);
   mkdirSync(CACHE_DIR, { recursive: true });
 
-  const tarPath = join(CACHE_DIR, tarball);
+  const archivePath = join(CACHE_DIR, archiveName);
 
   try {
     const data = await download(url);
-    require("fs").writeFileSync(tarPath, data);
+    require("fs").writeFileSync(archivePath, data);
 
     // Extract
-    execSync(`tar xzf "${tarPath}" -C "${CACHE_DIR}"`, { stdio: "pipe" });
-    execSync(`chmod +x "${binaryPath}"`, { stdio: "pipe" });
+    if (isWindows) {
+      // PowerShell Expand-Archive is present on Windows 10+ (PowerShell 5.0+).
+      const psEscape = (s) => s.replace(/'/g, "''");
+      execSync(
+        `powershell -NoProfile -Command "Expand-Archive -LiteralPath '${psEscape(archivePath)}' -DestinationPath '${psEscape(CACHE_DIR)}' -Force"`,
+        { stdio: "pipe" }
+      );
+    } else {
+      execSync(`tar xzf "${archivePath}" -C "${CACHE_DIR}"`, { stdio: "pipe" });
+      execSync(`chmod +x "${binaryPath}"`, { stdio: "pipe" });
+    }
 
-    // Clean up tarball
-    unlinkSync(tarPath);
+    // Clean up archive
+    unlinkSync(archivePath);
 
     console.error(`Installed phantom to ${binaryPath}`);
   } catch (err) {

--- a/npm/install.js
+++ b/npm/install.js
@@ -12,7 +12,8 @@ const CACHE_DIR = join(
   "bin"
 );
 
-const binaryPath = join(CACHE_DIR, "phantom");
+const binaryExt = process.platform === "win32" ? ".exe" : "";
+const binaryPath = join(CACHE_DIR, `phantom${binaryExt}`);
 
 if (existsSync(binaryPath)) {
   console.log("phantom binary already installed.");

--- a/npm/package.json
+++ b/npm/package.json
@@ -43,7 +43,8 @@
   },
   "os": [
     "darwin",
-    "linux"
+    "linux",
+    "win32"
   ],
   "cpu": [
     "x64",


### PR DESCRIPTION
Tier 3 of #1 (Windows support). Independent of Tier 2 (#17) — separate branch off main.

## Summary

The npm wrapper actively refused to install on Windows. This PR unblocks the Windows install path so `npx phantom-secrets init` works on Windows after a release bump.

### Changes
- **`package.json`** — add `"win32"` to `os` array (was blocking install with `EBADPLATFORM`)
- **`bin/cli.js`** — map `win32-x64` to `x86_64-pc-windows-msvc`, download `.zip` on Windows (Rust release workflow already builds it), extract via PowerShell `Expand-Archive`, skip `chmod +x`
- **`install.js`** — respect `.exe` suffix in the existing-binary check

## Release coordination

Must not publish this to npm until a `v0.5.0+` tag exists with Windows binaries. Today the latest published tag is `v0.4.0` which has no Windows artifacts; if this wrapper shipped now, Windows installs would fetch a 404. Tier 4 of #1 handles the coordinated release.

## Test plan

- CI continues to pass on the Rust workspace (this PR only touches the npm wrapper, so CI behavior is unchanged from main)
- Manual test once v0.5.0 is published: `npx phantom-secrets@0.5.0 init` on a Windows machine
- Edge cases covered in the PowerShell escape: paths with single quotes (doubled via `'' -> '''`)

Closes #15