### PR TITLE
fix(mcp): allow dead_code on tool_router

### DIFF
--- a/crates/phantom-mcp/src/server.rs
+++ b/crates/phantom-mcp/src/server.rs
@@ -154,6 +154,9 @@ fn write_package_json(pkg_path: &std::path::Path, pkg: &serde_json::Value) -> Re
 
 #[derive(Debug, Clone)]
 pub struct PhantomMcpServer {
+    // rmcp's #[tool_router] / #[tool_handler] macros consume this field via
+    // generated code that clippy's dead-code pass can't see through.
+    #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
     project_dir: PathBuf,
 }


### PR DESCRIPTION
Post-release hotfix — restores CI to green on main.

## Background

The v0.5.0 release (landed via #19, tagged at e0812d8) refreshed Cargo.lock, which pulled \`rmcp\` from whatever previous 1.x was pinned up to \`1.5.0\` (our manifest declares \`rmcp = "1"\` — caret range). The new rmcp macro expansion no longer exposes the \`tool_router\` field read to clippy's dead-code analysis, so Lint started failing on main:

\`\`\`
error: field \`tool_router\` is never read
   --> crates/phantom-mcp/src/server.rs:157:5
\`\`\`

## Why the release is fine

- The field IS used — rmcp's \`#[tool_router]\` / \`#[tool_handler]\` macros consume it via generated code clippy can't trace.
- Release builds don't enable \`-D warnings\`, so the v0.5.0 binaries were produced successfully and work correctly.
- Only \`cargo clippy --all-targets -- -D warnings\` was affected.

## Fix

One-line annotation with a comment explaining what clippy can't see. No behavior change.

## Test plan
- [ ] Lint green
- [ ] Test matrix green