### PR TITLE
v0.5.1: Windows polish (shell syntax, README)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,7 +1510,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phantom"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "phantom-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "hex",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "phantom-mcp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "phantom-proxy"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytes",
  "hex",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "phantom-vault"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/ashlrai/phantom-secrets"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,33 @@ $ phantom exec -- claude
 # Proxy running on 127.0.0.1:54321 — AI sees phantom tokens, proxy injects real keys
 ```
 
+### Windows
+
+The same commands work on Windows. `npx phantom-secrets init` installs via npm as on macOS/Linux.
+
+After `phantom start --daemon`, the CLI detects your shell and prints the matching env-var syntax. For reference:
+
+**PowerShell:**
+```powershell
+$env:OPENAI_BASE_URL = "http://127.0.0.1:PORT/openai"
+$env:PHANTOM_PROXY_PORT = "PORT"
+$env:PHANTOM_PROXY_TOKEN = "TOKEN"
+```
+
+**cmd.exe:**
+```cmd
+set OPENAI_BASE_URL=http://127.0.0.1:PORT/openai
+set PHANTOM_PROXY_PORT=PORT
+set PHANTOM_PROXY_TOKEN=TOKEN
+```
+
+**Git Bash / WSL:** use the `export X=Y` syntax from the main quick-start.
+
+Notes:
+- If `phantom.exe` fails to run with "Application Control policy has blocked this file," Windows Smart App Control is honoring the downloaded file's Mark-of-the-Web tag. One-time fix from PowerShell: `Get-ChildItem "$env:USERPROFILE\.phantom-secrets\bin\*.exe" | Unblock-File`.
+- Clipboard auto-clear (`phantom reveal --copy` clears after 30s) is macOS-only — tracked in [#9](https://github.com/ashlrai/phantom-secrets/issues/9). Clipboard copy itself works on all platforms.
+- Windows-on-ARM64 not yet packaged — x64 only. Tracker: [#1](https://github.com/ashlrai/phantom-secrets/issues/1).
+
 ## How It Works
 
 ```

--- a/crates/phantom-cli/src/commands/start.rs
+++ b/crates/phantom-cli/src/commands/start.rs
@@ -7,6 +7,59 @@ use phantom_proxy::{Interceptor, ProxyConfig, ProxyServer, ServiceRegistry};
 use std::collections::HashMap;
 use std::process::{Command, Stdio};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShellSyntax {
+    Bash,
+    PowerShell,
+    Cmd,
+}
+
+fn detect_shell_syntax() -> ShellSyntax {
+    // POSIX shells (incl. Git Bash on Windows, WSL, macOS, Linux) set $SHELL.
+    if let Ok(sh) = std::env::var("SHELL") {
+        let lower = sh.to_lowercase();
+        if lower.contains("bash")
+            || lower.contains("zsh")
+            || lower.contains("fish")
+            || lower.ends_with("/sh")
+        {
+            return ShellSyntax::Bash;
+        }
+    }
+    // $PSModulePath is set by PowerShell on Windows and nowhere else.
+    if std::env::var("PSModulePath").is_ok() {
+        return ShellSyntax::PowerShell;
+    }
+    #[cfg(windows)]
+    {
+        ShellSyntax::Cmd
+    }
+    #[cfg(not(windows))]
+    {
+        ShellSyntax::Bash
+    }
+}
+
+fn format_export(syntax: ShellSyntax, var: &str, value: &str) -> String {
+    match syntax {
+        ShellSyntax::Bash => format!("  export {}={}", var, value),
+        ShellSyntax::PowerShell => format!("  $env:{} = \"{}\"", var, value),
+        ShellSyntax::Cmd => format!("  set {}={}", var, value),
+    }
+}
+
+fn shell_hint(syntax: ShellSyntax) -> &'static str {
+    match syntax {
+        ShellSyntax::Bash => {
+            "  # Detected bash/zsh/fish. PowerShell: `$env:X = \"Y\"`. cmd: `set X=Y`."
+        }
+        ShellSyntax::PowerShell => "  # Detected PowerShell. bash: `export X=Y`. cmd: `set X=Y`.",
+        ShellSyntax::Cmd => {
+            "  # Assuming cmd.exe. PowerShell: `$env:X = \"Y\"`. bash: `export X=Y`."
+        }
+    }
+}
+
 pub fn run(daemon: bool) -> Result<()> {
     if daemon {
         return run_daemon();
@@ -106,12 +159,20 @@ fn run_daemon() -> Result<()> {
         "\n{} Set these env vars in your shell:\n",
         "->".blue().bold()
     );
+    let syntax = detect_shell_syntax();
     let overrides = registry.base_url_overrides_with_token(port, Some(proxy_token));
     for (env_var, url) in &overrides {
-        println!("  export {}={}", env_var, url);
+        println!("{}", format_export(syntax, env_var, url));
     }
-    println!("  export PHANTOM_PROXY_PORT={}", port);
-    println!("  export PHANTOM_PROXY_TOKEN={}", proxy_token);
+    println!(
+        "{}",
+        format_export(syntax, "PHANTOM_PROXY_PORT", &port.to_string())
+    );
+    println!(
+        "{}",
+        format_export(syntax, "PHANTOM_PROXY_TOKEN", proxy_token)
+    );
+    println!("\n{}", shell_hint(syntax));
 
     println!(
         "\n{} Running in background. Use {} to stop.",
@@ -217,12 +278,20 @@ async fn run_async() -> Result<()> {
         "\n{} Set these env vars in your shell:\n",
         "->".blue().bold()
     );
+    let syntax = detect_shell_syntax();
     let overrides = registry.base_url_overrides_with_token(port, Some(&proxy_token));
     for (env_var, url) in &overrides {
-        println!("  export {}={}", env_var, url);
+        println!("{}", format_export(syntax, env_var, url));
     }
-    println!("  export PHANTOM_PROXY_PORT={}", port);
-    println!("  export PHANTOM_PROXY_TOKEN={}", proxy_token);
+    println!(
+        "{}",
+        format_export(syntax, "PHANTOM_PROXY_PORT", &port.to_string())
+    );
+    println!(
+        "{}",
+        format_export(syntax, "PHANTOM_PROXY_TOKEN", &proxy_token)
+    );
+    println!("\n{}", shell_hint(syntax));
 
     println!("\n{} Press Ctrl-C to stop the proxy.\n", "->".blue().bold());
     tokio::signal::ctrl_c().await?;

--- a/npm/bin/cli.js
+++ b/npm/bin/cli.js
@@ -6,7 +6,7 @@ const { join } = require("path");
 const https = require("https");
 const { execSync } = require("child_process");
 
-const VERSION = "0.5.0";
+const VERSION = "0.5.1";
 const REPO = "ashlrai/phantom-secrets";
 const CACHE_DIR = join(
   process.env.HOME || process.env.USERPROFILE || "/tmp",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantom-secrets",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Prevent AI coding agents from leaking your API keys. Replaces real secrets with phantom tokens; a local proxy swaps them back at the network layer.",
   "bin": {
     "phantom-secrets": "bin/cli.js",


### PR DESCRIPTION
Windows polish pass before first `npm publish`. Keeps the first-run experience sane for Windows users.

## Summary
- **cli(start): shell-aware env-var syntax (#21)** — detect \`\$SHELL\` / \`\$PSModulePath\` / cfg(windows) and emit bash \`export X=Y\`, PowerShell \`\$env:X = \"Y\"\`, or cmd \`set X=Y\`. Prints a one-line hint with the alternatives. Previously printed bash unconditionally.
- **docs: README Windows section (#12)** — install, env-var syntax per shell, Smart App Control note, known gaps link.
- **chore: version 0.5.0 → 0.5.1** — workspace + npm + cli.js VERSION.

## Test plan
- [ ] CI green on \`ubuntu-latest\`
- [ ] CI green on \`macos-latest\`
- [ ] CI green on \`windows-latest\`
- [ ] Manual Windows smoke test per [PowerShell block in the plan](https://github.com/ashlrai/phantom-secrets/issues/1) after v0.5.1 binaries build

## Release flow after merge
1. Tag \`v0.5.0\` → wait — actually \`v0.5.1\`. Pushing the tag triggers \`release.yml\`.
2. Smoke test the Windows binary.
3. Co-founder adds npm maintainer, \`npm publish\` from \`npm/\`.

Closes #12, #21