### PR TITLE
fix(cli): silence dead_code for ShellSyntax::Cmd on non-Windows

### DIFF
--- a/crates/phantom-cli/src/commands/start.rs
+++ b/crates/phantom-cli/src/commands/start.rs
@@ -11,6 +11,7 @@ use std::process::{Command, Stdio};
 enum ShellSyntax {
     Bash,
     PowerShell,
+    #[cfg_attr(not(windows), allow(dead_code))]
     Cmd,
 }
 


### PR DESCRIPTION
## Summary
- `ShellSyntax::Cmd` is only constructed inside `#[cfg(windows)]`, so Linux CI was failing `cargo clippy --all-targets -- -D warnings` with a `dead_code` error on the variant.
- Added `#[cfg_attr(not(windows), allow(dead_code))]` so the variant stays available for the `cfg(windows)` path and the match arms without tripping the lint on other targets.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` (local, Windows) — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Linux CI clippy job — verify on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)