### PR TITLE
fix(npm): verify release binary SHA-256 before extracting (audit F1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,20 @@ jobs:
         with:
           path: artifacts
 
+      - name: Generate SHA-256 checksums
+        working-directory: artifacts
+        run: |
+          set -euo pipefail
+          : > ../SHA256SUMS
+          while IFS= read -r -d '' f; do
+            base=$(basename "$f")
+            dir=$(dirname "$f")
+            (cd "$dir" && sha256sum "$base") | tee "$f.sha256" >> ../SHA256SUMS
+          done < <(find . -type f \( -name '*.tar.gz' -o -name '*.zip' \) -print0 | sort -z)
+          mv ../SHA256SUMS ./SHA256SUMS
+          echo "--- SHA256SUMS ---"
+          cat SHA256SUMS
+
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
@@ -86,3 +100,5 @@ jobs:
           files: |
             artifacts/**/*.tar.gz
             artifacts/**/*.zip
+            artifacts/**/*.sha256
+            artifacts/SHA256SUMS

--- a/npm/bin/cli.js
+++ b/npm/bin/cli.js
@@ -4,6 +4,7 @@ const { execFileSync } = require("child_process");
 const { existsSync, mkdirSync, createWriteStream, unlinkSync } = require("fs");
 const { join } = require("path");
 const https = require("https");
+const crypto = require("crypto");
 const { execSync } = require("child_process");
 
 const VERSION = "0.5.1";
@@ -57,6 +58,15 @@ function download(url) {
   });
 }
 
+function parseSha256File(buf, expectedFilename) {
+  // Standard `sha256sum` / `shasum -a 256` format: "<64-hex>  <filename>\n"
+  const line = buf.toString("utf8").trim().split(/\r?\n/)[0] || "";
+  const m = line.match(/^([0-9a-f]{64})\s+\*?(.+)$/i);
+  if (!m) return null;
+  if (expectedFilename && m[2].trim() !== expectedFilename) return null;
+  return m[1].toLowerCase();
+}
+
 async function ensureBinary() {
   const binaryPath = getBinaryPath();
 
@@ -69,6 +79,7 @@ async function ensureBinary() {
   const archiveExt = isWindows ? "zip" : "tar.gz";
   const archiveName = `phantom-${target}.${archiveExt}`;
   const url = `https://github.com/${REPO}/releases/download/v${VERSION}/${archiveName}`;
+  const sha256Url = `${url}.sha256`;
 
   console.error(`Downloading phantom v${VERSION} for ${target}...`);
   mkdirSync(CACHE_DIR, { recursive: true });
@@ -76,7 +87,30 @@ async function ensureBinary() {
   const archivePath = join(CACHE_DIR, archiveName);
 
   try {
+    // Fetch the checksum first so we fail before we've written anything to disk
+    // if the release is missing its .sha256 sidecar.
+    const sumBuf = await download(sha256Url);
+    const expected = parseSha256File(sumBuf, archiveName);
+    if (!expected) {
+      throw new Error(
+        `malformed or missing checksum at ${sha256Url} — refusing to install unverified binary`
+      );
+    }
+
     const data = await download(url);
+
+    const actual = crypto.createHash("sha256").update(data).digest("hex");
+    const expectedBuf = Buffer.from(expected, "hex");
+    const actualBuf = Buffer.from(actual, "hex");
+    if (
+      expectedBuf.length !== actualBuf.length ||
+      !crypto.timingSafeEqual(expectedBuf, actualBuf)
+    ) {
+      throw new Error(
+        `SHA-256 mismatch for ${archiveName}: expected ${expected}, got ${actual}`
+      );
+    }
+
     require("fs").writeFileSync(archivePath, data);
 
     // Extract


### PR DESCRIPTION
Addresses **F1 (critical)** from the v0.5.1 security audit: the npm wrapper was downloading release tarballs from GitHub Releases and executing them with zero integrity verification. Any compromise of Release-asset write (stolen token, maintainer account takeover, Actions supply-chain) let an attacker ship a trojaned phantom binary to every user doing \`npx phantom-secrets\` or a fresh global install.

## Changes
- **\`.github/workflows/release.yml\`** — after \`download-artifact\`, generate per-archive \`.sha256\` sidecars (GNU \`sha256sum\` format) and a consolidated \`SHA256SUMS\`; upload all to the GitHub Release.
- **\`npm/bin/cli.js\`** — before extraction, fetch \`{archive}.sha256\`, parse the hash (rejects garbage / wrong filename), compute SHA-256 of the downloaded bytes, compare via \`crypto.timingSafeEqual\`. Fail closed on missing/malformed sidecar or mismatch.

## Honest threat-model note
The \`.sha256\` file is served from the same GitHub Release as the tarball, so an attacker with Release-asset write access can swap both. What this PR actually buys:
- Closes the specific "attacker swapped *only* the tarball" path (e.g. a flawed-but-narrow upload permission, a transient MITM scenario, or accidental republish of the wrong binary).
- Produces the sidecars a later signature scheme (cosign detached sig, minisign) can sign over.
- Establishes fail-closed install behavior — no silent downgrade.

Natural follow-ups (worth opening tickets for):
1. Bake the per-target SHA-256s into the npm package itself, so the trust anchor is npm registry + maintainer 2FA rather than the same Release.
2. Add cosign keyless signing in the release workflow, verify in \`cli.js\` with the sigstore pubkey bundled in the npm package.

## Test plan
- [x] \`node --check\` on updated \`cli.js\` passes
- [x] \`parseSha256File\` unit-tested locally against GNU format, BSD \`*filename\` format, garbage input, short-hex input, wrong-filename rejection — all pass
- [x] \`crypto.timingSafeEqual\` behavior confirmed for matching / mismatching buffers
- [x] \`release.yml\` parses via \`yaml.safe_load\`
- [ ] Next release (v0.5.2+) — verify \`SHA256SUMS\` + \`.sha256\` assets appear on the GitHub Release, and a fresh \`npx phantom-secrets\` succeeds with verification path

🤖 Generated with [Claude Code](https://claude.com/claude-code)