### PR TITLE
fix(vault): zeroize plaintext JSON in FileVault (audit F7)

### DIFF
--- a/crates/phantom-vault/src/file.rs
+++ b/crates/phantom-vault/src/file.rs
@@ -79,15 +79,23 @@ impl FileVault {
         }
 
         let encrypted = std::fs::read(&self.vault_path)?;
-        let plaintext = crypto::decrypt(&encrypted, &self.passphrase)?;
+        // Wrap the decrypted JSON in Zeroizing so the heap buffer is overwritten
+        // with zeros when it drops — whether that's on success or on an early
+        // return from the serde_json error path below.
+        let plaintext = zeroize::Zeroizing::new(crypto::decrypt(&encrypted, &self.passphrase)?);
 
-        serde_json::from_slice(&plaintext)
+        serde_json::from_slice::<VaultData>(&plaintext)
             .map_err(|e| PhantomError::VaultError(format!("Corrupt vault data: {e}")))
     }
 
     fn save(&self, data: &VaultData) -> Result<()> {
-        let plaintext = serde_json::to_string_pretty(data)
-            .map_err(|e| PhantomError::VaultError(format!("Serialize error: {e}")))?;
+        // The plaintext JSON holds every secret in the vault. Wrap it in
+        // Zeroizing so the heap allocation is scrubbed on drop — including on
+        // the error paths below. String's own Drop does not zero memory.
+        let plaintext = zeroize::Zeroizing::new(
+            serde_json::to_string_pretty(data)
+                .map_err(|e| PhantomError::VaultError(format!("Serialize error: {e}")))?,
+        );
 
         let encrypted = crypto::encrypt(plaintext.as_bytes(), &self.passphrase)?;
 


### PR DESCRIPTION
Addresses **F7 (medium)** from the v0.5.1 security audit. \`FileVault::save\` was serializing \`VaultData\` into a plain \`String\` (via \`serde_json::to_string_pretty\`), passing its bytes to \`crypto::encrypt\`, and dropping the \`String\` normally. \`String\`'s Drop does not zero the heap allocation — so every vault-save left a plaintext copy of every stored secret sitting in freed heap memory until the allocator happened to overwrite it. Same shape in \`FileVault::load\` with a \`Vec<u8>\` from \`crypto::decrypt\`.

## Changes
- Wrap both the save \`String\` and the load \`Vec<u8>\` in \`zeroize::Zeroizing\` so drop scrubs the buffer on every exit path (success *and* serde-error).
- No behavior change beyond the secure-drop. \`zeroize\` was already a dependency.

## Test plan
- [x] \`cargo test -p phantom-vault\` — 14 passed, 0 failed (existing roundtrip / encrypt-not-leaking-plaintext tests still cover the happy path).
- [x] \`cargo clippy --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [ ] CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)