### PR TITLE
fix(cli): write .phantom.pid with 0o600 from creation (audit F8)

### DIFF
--- a/crates/phantom-cli/src/commands/start.rs
+++ b/crates/phantom-cli/src/commands/start.rs
@@ -250,18 +250,14 @@ async fn run_async() -> Result<()> {
 
     let port = proxy.port();
 
-    // Write PID file atomically (temp + rename) so daemon parent never reads partial data.
+    // Write PID file atomically. The PID file contains the proxy auth token,
+    // so the tempfile must have restrictive permissions from the moment of
+    // creation — not set afterward. phantom_core::fs::atomic_write stages
+    // through `tempfile::NamedTempFile` which creates with mode 0o600 on POSIX
+    // before the first byte is written, then renames over the target atomically.
+    // Fixes F8 from the 0.5.1 security audit (world-readable race window).
     let pid_info = format!("{}:{}:{}", std::process::id(), port, proxy_token);
-    let tmp_pid = pid_path.with_extension("tmp");
-    std::fs::write(&tmp_pid, &pid_info)?;
-    std::fs::rename(&tmp_pid, &pid_path)?;
-
-    // Set restrictive permissions — PID file contains proxy token
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&pid_path, std::fs::Permissions::from_mode(0o600))?;
-    }
+    phantom_core::fs::atomic_write(&pid_path, pid_info.as_bytes())?;
 
     println!(
         "{} Proxy started on {}",


### PR DESCRIPTION
Addresses **F8 (medium)** from the v0.5.1 security audit.

The PID file contains the proxy auth token. The prior code path wrote the tempfile with default umask permissions (typically \`0o644\`), renamed over the target, and then chmod'd to \`0o600\`. That left a race window during which an unprivileged local process could inotify/read the file and grab the token — which enables proxy abuse (real-secret substitution on any configured upstream). Windows had no chmod step at all.

## Fix
Replace the whole write/rename/chmod sequence with \`phantom_core::fs::atomic_write\` (introduced in #27). That helper stages through \`tempfile::NamedTempFile::new_in\`, which on POSIX creates the tempfile with mode \`0o600\` *before the first byte is written*, then renames over the target atomically. No post-rename chmod, no race.

## Test plan
- [x] \`cargo build --workspace\` clean.
- [x] \`cargo clippy --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [ ] CI matrix.

## Follow-up
Secure-Design #10 from the audit recommends dropping the proxy token from \`.phantom.pid\` entirely (move it to the OS keychain and leave only \`{pid}:{port}\` on disk). That's a bigger behavior change and is deliberately out of scope here — can be its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)