### PR TITLE
ci: pin third-party Actions to commit SHAs + scope GITHUB_TOKEN (audit F10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# Scope GITHUB_TOKEN down — CI only needs to read the repo.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -17,9 +21,13 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      # Third-party actions are pinned to commit SHAs (not floating tags) so
+      # a future tag-move or account compromise on the action repo cannot
+      # inject steps into our CI. Keep the trailing `# v…` comment so
+      # dependabot knows what version is in effect.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-24)
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build
         run: cargo build --verbose
       - name: Run tests
@@ -29,11 +37,11 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-24)
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,17 @@ on:
     tags:
       - 'v*'
 
+# Default GITHUB_TOKEN to read-only; each job that needs write must opt in.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    # Build doesn't push anywhere — read-only token.
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -31,11 +35,12 @@ jobs:
             os: windows-latest
             artifact: phantom-x86_64-pc-windows-msvc
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      # Third-party actions pinned to commit SHAs — see ci.yml for rationale.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-24)
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install cross-compilation tools
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -64,7 +69,7 @@ jobs:
         shell: bash
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}.*
@@ -73,9 +78,12 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    # Release job needs write to publish the Release and upload assets.
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
 
@@ -94,7 +102,7 @@ jobs:
           cat SHA256SUMS
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
Addresses **F10 (medium)** from the v0.5.1 security audit.

Third-party Actions were pinned to floating tags (\`@v4\`, \`@v2\`). Those are mutable — a re-tag on the upstream repo (intentional or via account compromise) silently ships new code into every CI run. Release workflow is the highest-value target (it builds the binaries users install), which ties back into F1.

## Changes
- Every \`uses:\` now pins to a commit SHA with a trailing \`# v…\` comment so Dependabot can manage updates and humans can see the logical version:
  - \`actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\`
  - \`dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-04-24 snapshot)\`
  - \`Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2\`
  - \`actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4\`
  - \`actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4\`
  - \`softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2\`
- **\`permissions:\` blocks added.** \`ci.yml\` gets top-level \`contents: read\` (CI never writes). \`release.yml\` gets top-level \`contents: read\`, then \`build\` explicitly keeps \`contents: read\` and only the \`release\` job gets \`contents: write\` for the actual Release publish.

## Follow-up
Set up Dependabot to keep these SHA pins fresh (a follow-up PR).

## Test plan
- [x] Both workflows parse via \`yaml.safe_load\`.
- [ ] CI run on this branch confirms no regression (same matrix as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)