### PR TITLE
fix(proxy): scope phm-token substitution to safe locations (audit F9)

### DIFF
--- a/crates/phantom-proxy/src/body_scope.rs
+++ b/crates/phantom-proxy/src/body_scope.rs
@@ -1,0 +1,309 @@
+//! Scope control for phantom-token substitution in outbound requests.
+//!
+//! Blind string-replace across an entire request body is a defense-in-depth
+//! violation (F9): any `phm_...` substring a user types into a chat message
+//! body would be rewritten to the real secret before the upstream ever sees
+//! it. This module restricts substitution to:
+//!
+//! - A whitelist of auth-bearing request header names, plus the per-service
+//!   configured header (e.g. `Authorization`, `x-api-key`).
+//! - For `application/json` bodies: a whitelist of known-secret-bearing JSON
+//!   field names, matched at any depth.
+//!
+//! Anywhere else, if a phm-token is present, we log a warning and pass the
+//! body through unchanged — so a misconfigured client fails loudly instead
+//! of silently leaking a substituted secret to an unexpected field.
+
+use crate::interceptor::Interceptor;
+use tracing::{debug, warn};
+
+/// Request header names (lowercase) where phm-token substitution is allowed.
+/// The per-route configured header (`ServiceRoute.header`) is also allowed
+/// on top of this list.
+const DEFAULT_ALLOWED_HEADERS: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "x-api-key",
+    "api-key",
+    "x-auth-token",
+    "x-access-token",
+    "cookie",
+];
+
+/// JSON field names (lowercase) where substitution is allowed inside
+/// `application/json` request bodies. Matched at any depth.
+const DEFAULT_ALLOWED_JSON_FIELDS: &[&str] = &[
+    "api_key",
+    "apikey",
+    "key",
+    "token",
+    "access_token",
+    "auth_token",
+    "authorization",
+    "secret",
+    "password",
+];
+
+/// Returns true if `name` is a header where phm-token substitution is
+/// permitted. `service_header` is the per-route configured header name
+/// (may be empty for non-routed paths).
+pub fn is_allowed_header(name: &str, service_header: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    if DEFAULT_ALLOWED_HEADERS.iter().any(|h| *h == lower) {
+        return true;
+    }
+    !service_header.is_empty() && service_header.eq_ignore_ascii_case(&lower)
+}
+
+fn is_allowed_json_field(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    DEFAULT_ALLOWED_JSON_FIELDS.iter().any(|f| *f == lower)
+}
+
+fn is_json_content_type(ct: &str) -> bool {
+    let lower = ct.to_ascii_lowercase();
+    // "application/json", "application/json; charset=utf-8",
+    // "application/vnd.api+json", etc.
+    if let Some(mime) = lower.split(';').next() {
+        let mime = mime.trim();
+        mime == "application/json" || (mime.starts_with("application/") && mime.ends_with("+json"))
+    } else {
+        false
+    }
+}
+
+/// Apply phantom-token substitution to a request body, restricted by
+/// content-type. Returns the (possibly rewritten) body and whether any
+/// substitution happened.
+///
+/// - `application/json` (and `*+json`): recursively replaces phm tokens
+///   inside string values whose parent key is in the allowlist. Tokens
+///   outside allowed fields are left untouched and a warning is logged.
+/// - Any other / absent content-type: body is returned unchanged. If a phm
+///   token is present a debug log is emitted; no substitution is performed.
+pub fn scoped_body_replace(
+    interceptor: &Interceptor,
+    content_type: Option<&str>,
+    body: &[u8],
+) -> (Vec<u8>, bool) {
+    let ct = content_type.unwrap_or("");
+    if is_json_content_type(ct) {
+        match serde_json::from_slice::<serde_json::Value>(body) {
+            Ok(mut v) => {
+                let replaced = replace_in_json(&mut v, interceptor);
+                if replaced {
+                    match serde_json::to_vec(&v) {
+                        Ok(out) => (out, true),
+                        Err(_) => (body.to_vec(), false),
+                    }
+                } else {
+                    warn_if_phantom_present(interceptor, body, "JSON body outside allowed fields");
+                    (body.to_vec(), false)
+                }
+            }
+            Err(_) => {
+                warn_if_phantom_present(interceptor, body, "malformed JSON body");
+                (body.to_vec(), false)
+            }
+        }
+    } else {
+        if !body.is_empty() {
+            if let Ok(s) = std::str::from_utf8(body) {
+                if interceptor.contains_phantom_token(s) {
+                    debug!(
+                        "phantom token in request body with content-type {:?} — not substituted (F9 scope)",
+                        ct
+                    );
+                }
+            }
+        }
+        (body.to_vec(), false)
+    }
+}
+
+fn warn_if_phantom_present(interceptor: &Interceptor, body: &[u8], ctx: &str) {
+    if let Ok(s) = std::str::from_utf8(body) {
+        if interceptor.contains_phantom_token(s) {
+            warn!("phantom token in {ctx} — not substituted (F9 scope)");
+        }
+    }
+}
+
+fn replace_in_json(value: &mut serde_json::Value, interceptor: &Interceptor) -> bool {
+    let mut replaced = false;
+    match value {
+        serde_json::Value::Object(map) => {
+            let keys: Vec<String> = map.keys().cloned().collect();
+            for key in keys {
+                let allowed = is_allowed_json_field(&key);
+                if let Some(child) = map.get_mut(&key) {
+                    if allowed {
+                        if let serde_json::Value::String(s) = child {
+                            let (new_s, did) = interceptor.replace_in_str(s);
+                            if did {
+                                debug!("Replaced phantom token in JSON field: {}", key);
+                                *s = new_s;
+                                replaced = true;
+                            }
+                        }
+                    }
+                    // Recurse regardless so nested allowed fields are still handled
+                    if replace_in_json(child, interceptor) {
+                        replaced = true;
+                    }
+                }
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for item in arr.iter_mut() {
+                if replace_in_json(item, interceptor) {
+                    replaced = true;
+                }
+            }
+        }
+        _ => {}
+    }
+    replaced
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    const PHM: &str = "phm_aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222";
+    const REAL: &str = "sk-real-openai-key-12345";
+
+    fn interceptor() -> Interceptor {
+        let mut m = HashMap::new();
+        m.insert(PHM.to_string(), REAL.to_string());
+        Interceptor::new(m)
+    }
+
+    #[test]
+    fn allowed_header_default_list() {
+        assert!(is_allowed_header("Authorization", ""));
+        assert!(is_allowed_header("authorization", ""));
+        assert!(is_allowed_header("X-API-Key", ""));
+        assert!(is_allowed_header("Cookie", ""));
+    }
+
+    #[test]
+    fn allowed_header_per_service() {
+        assert!(is_allowed_header("X-Custom-Auth", "x-custom-auth"));
+        assert!(is_allowed_header("x-custom-auth", "X-Custom-Auth"));
+    }
+
+    #[test]
+    fn disallowed_header_rejected() {
+        assert!(!is_allowed_header("User-Agent", ""));
+        assert!(!is_allowed_header("X-Request-Id", "authorization"));
+        assert!(!is_allowed_header("Content-Type", ""));
+    }
+
+    #[test]
+    fn json_content_type_detection() {
+        assert!(is_json_content_type("application/json"));
+        assert!(is_json_content_type("application/json; charset=utf-8"));
+        assert!(is_json_content_type("APPLICATION/JSON"));
+        assert!(is_json_content_type("application/vnd.api+json"));
+        assert!(!is_json_content_type("text/plain"));
+        assert!(!is_json_content_type("application/xml"));
+        assert!(!is_json_content_type(""));
+    }
+
+    #[test]
+    fn json_body_allowed_field_replaced() {
+        let body = format!(r#"{{"model":"gpt-4","api_key":"{PHM}"}}"#);
+        let (out, did) =
+            scoped_body_replace(&interceptor(), Some("application/json"), body.as_bytes());
+        assert!(did);
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(out_str.contains(REAL));
+        assert!(!out_str.contains("phm_"));
+    }
+
+    #[test]
+    fn json_body_disallowed_field_not_replaced() {
+        // `prompt` is not in the allowlist — a phm_ token that happens to land
+        // in chat message content must NOT be substituted.
+        let body = format!(r#"{{"prompt":"I saw {PHM} in logs","model":"gpt-4"}}"#);
+        let (out, did) =
+            scoped_body_replace(&interceptor(), Some("application/json"), body.as_bytes());
+        assert!(!did);
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(
+            out_str.contains(PHM),
+            "phm token should survive un-substituted"
+        );
+        assert!(!out_str.contains(REAL));
+    }
+
+    #[test]
+    fn json_body_nested_allowed_field_replaced() {
+        let body = format!(r#"{{"config":{{"auth_token":"{PHM}"}}}}"#);
+        let (out, did) =
+            scoped_body_replace(&interceptor(), Some("application/json"), body.as_bytes());
+        assert!(did);
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(out_str.contains(REAL));
+    }
+
+    #[test]
+    fn json_body_multiple_fields_mixed() {
+        let body = format!(
+            r#"{{"api_key":"{PHM}","prompt":"contains {PHM} too","messages":[{{"role":"user","content":"tell me about {PHM}"}}]}}"#
+        );
+        let (out, did) =
+            scoped_body_replace(&interceptor(), Some("application/json"), body.as_bytes());
+        assert!(did);
+        let out_str = std::str::from_utf8(&out).unwrap();
+        // api_key got replaced
+        assert!(out_str.contains(REAL));
+        // But the phm token in `prompt` and `content` remains
+        assert!(out_str.contains(PHM));
+    }
+
+    #[test]
+    fn non_json_body_not_replaced() {
+        let body = format!("grant_type=client_credentials&client_secret={PHM}");
+        let (out, did) = scoped_body_replace(
+            &interceptor(),
+            Some("application/x-www-form-urlencoded"),
+            body.as_bytes(),
+        );
+        assert!(!did);
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(out_str.contains(PHM));
+        assert!(!out_str.contains(REAL));
+    }
+
+    #[test]
+    fn malformed_json_not_replaced() {
+        let body = format!(r#"{{"api_key": "{PHM}""#); // missing closing
+        let (out, did) =
+            scoped_body_replace(&interceptor(), Some("application/json"), body.as_bytes());
+        assert!(!did);
+        assert_eq!(out, body.as_bytes());
+    }
+
+    #[test]
+    fn empty_body_passes_through() {
+        let (out, did) = scoped_body_replace(&interceptor(), Some("application/json"), b"");
+        assert!(!did);
+        assert_eq!(out, b"");
+    }
+
+    #[test]
+    fn content_type_with_charset_still_parses() {
+        let body = format!(r#"{{"api_key":"{PHM}"}}"#);
+        let (out, did) = scoped_body_replace(
+            &interceptor(),
+            Some("application/json; charset=utf-8"),
+            body.as_bytes(),
+        );
+        assert!(did);
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(out_str.contains(REAL));
+    }
+}

--- a/crates/phantom-proxy/src/lib.rs
+++ b/crates/phantom-proxy/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod body_scope;
 pub mod interceptor;
 pub mod server;
 pub mod services;

--- a/crates/phantom-proxy/src/server.rs
+++ b/crates/phantom-proxy/src/server.rs
@@ -1,3 +1,4 @@
+use crate::body_scope;
 use crate::interceptor::Interceptor;
 use crate::services::ServiceRegistry;
 use bytes::Bytes;
@@ -251,12 +252,23 @@ async fn handle_request(
     let target_url = format!("{}{}{}", route.target_base, remainder, query);
     debug!("Proxying to: {}", target_url);
 
+    // Capture the request content-type before consuming `req` for its body —
+    // we need it to drive content-type-aware body substitution (F9).
+    let request_content_type = req
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
     // Build the outgoing request
     let mut outgoing = state.http_client.request(method.clone(), &target_url);
 
-    // Copy and transform headers
+    // Copy and transform headers. F9: phm-token substitution is restricted to
+    // a whitelist of auth-bearing header names plus the per-route configured
+    // header. Tokens present in other headers are passed through unchanged
+    // and logged — substituting them would turn arbitrary request metadata
+    // into a secret-leakage vector.
     for (name, value) in req.headers() {
-        // Skip hop-by-hop headers and our custom headers
         let name_str = name.as_str();
         if matches!(
             name_str,
@@ -270,12 +282,22 @@ async fn handle_request(
         }
 
         if let Ok(value_str) = value.to_str() {
-            // Replace phantom tokens in header values
-            let (replaced_value, did_replace) = state.interceptor.replace_in_str(value_str);
-            if did_replace {
-                debug!("Replaced phantom token in header: {}", name_str);
-            }
-            outgoing = outgoing.header(name_str, replaced_value);
+            let header_value = if body_scope::is_allowed_header(name_str, &route.header) {
+                let (replaced_value, did_replace) = state.interceptor.replace_in_str(value_str);
+                if did_replace {
+                    debug!("Replaced phantom token in header: {}", name_str);
+                }
+                replaced_value
+            } else {
+                if state.interceptor.contains_phantom_token(value_str) {
+                    warn!(
+                        "phantom token in non-allowed request header '{}' — not substituted (F9 scope)",
+                        name_str
+                    );
+                }
+                value_str.to_string()
+            };
+            outgoing = outgoing.header(name_str, header_value);
         } else {
             outgoing = outgoing.header(name, value.clone());
         }
@@ -309,9 +331,16 @@ async fn handle_request(
     };
 
     if !body_bytes.is_empty() {
-        let (replaced_body, did_replace) = state.interceptor.replace_in_bytes(&body_bytes);
+        // F9: content-type-scoped substitution. JSON bodies get field-level
+        // replacement on a whitelist of known-secret fields; other
+        // content-types pass through without substitution.
+        let (replaced_body, did_replace) = body_scope::scoped_body_replace(
+            &state.interceptor,
+            request_content_type.as_deref(),
+            &body_bytes,
+        );
         if did_replace {
-            debug!("Replaced phantom token(s) in request body");
+            debug!("Replaced phantom token(s) in request body (scoped)");
         }
         outgoing = outgoing.body(replaced_body);
     }
@@ -711,6 +740,134 @@ mod tests {
         let received_body = String::from_utf8(requests[0].body.clone()).unwrap();
         assert!(received_body.contains(real_secret));
         assert!(!received_body.contains("phm_"));
+
+        proxy.shutdown().await;
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_proxy_does_not_replace_phantom_token_in_disallowed_body_field() {
+        // F9 regression: a phm token landing in a non-secret JSON field
+        // (e.g. "prompt" / message content) must NOT be substituted to the
+        // real secret before forwarding upstream.
+        let mock = crate::test_server::MockServer::start().await;
+
+        let phantom_token = "phm_cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222cccc3333dddd4444";
+        let real_secret = "sk-must-not-leak-upstream";
+
+        let mut registry = ServiceRegistry::new();
+        registry.add_route(ServiceRoute {
+            name: "testapi".to_string(),
+            target_base: format!("http://127.0.0.1:{}", mock.port),
+            secret_key: "TEST_KEY".to_string(),
+            header: "Authorization".to_string(),
+            header_format: "Bearer {secret}".to_string(),
+        });
+
+        let mut mappings = HashMap::new();
+        mappings.insert(phantom_token.to_string(), real_secret.to_string());
+        let interceptor = Interceptor::new(mappings);
+
+        let proxy = ProxyServer::start(
+            ProxyConfig {
+                port: 0,
+                proxy_token: String::new(),
+                ..ProxyConfig::default()
+            },
+            registry,
+            interceptor,
+        )
+        .await
+        .unwrap();
+
+        // phm token appears only in `prompt` (chat content), never in an
+        // allowed field. The proxy must forward it unchanged.
+        let body = format!(
+            r#"{{"model":"gpt-4","messages":[{{"role":"user","content":"I saw {phantom_token} in logs"}}]}}"#
+        );
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("http://127.0.0.1:{}/testapi/v1/chat", proxy.port()))
+            .header("content-type", "application/json")
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+
+        let requests = mock.get_requests();
+        assert_eq!(requests.len(), 1);
+
+        let received_body = String::from_utf8(requests[0].body.clone()).unwrap();
+        assert!(
+            !received_body.contains(real_secret),
+            "real secret leaked into non-allowed body field: {received_body}"
+        );
+        assert!(
+            received_body.contains(phantom_token),
+            "phm token should have been forwarded un-substituted: {received_body}"
+        );
+
+        proxy.shutdown().await;
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_proxy_does_not_replace_phantom_token_in_disallowed_header() {
+        // F9 regression: a phm token in a non-auth header (e.g. User-Agent)
+        // must NOT be substituted to the real secret.
+        let mock = crate::test_server::MockServer::start().await;
+
+        let phantom_token = "phm_dddd4444eeee5555ffff6666aaaa1111bbbb2222cccc3333dddd4444eeee5555";
+        let real_secret = "sk-must-not-leak-in-ua";
+
+        let mut registry = ServiceRegistry::new();
+        registry.add_route(ServiceRoute {
+            name: "testapi".to_string(),
+            target_base: format!("http://127.0.0.1:{}", mock.port),
+            secret_key: "TEST_KEY".to_string(),
+            header: "Authorization".to_string(),
+            header_format: "Bearer {secret}".to_string(),
+        });
+
+        let mut mappings = HashMap::new();
+        mappings.insert(phantom_token.to_string(), real_secret.to_string());
+        let interceptor = Interceptor::new(mappings);
+
+        let proxy = ProxyServer::start(
+            ProxyConfig {
+                port: 0,
+                proxy_token: String::new(),
+                ..ProxyConfig::default()
+            },
+            registry,
+            interceptor,
+        )
+        .await
+        .unwrap();
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("http://127.0.0.1:{}/testapi/v1/ping", proxy.port()))
+            .header("User-Agent", format!("agent/{phantom_token}"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+
+        let requests = mock.get_requests();
+        let ua = requests[0].headers.get("user-agent").unwrap();
+        assert!(
+            !ua.contains(real_secret),
+            "real secret leaked into User-Agent: {ua}"
+        );
+        assert!(
+            ua.contains(phantom_token),
+            "phm token should be forwarded: {ua}"
+        );
 
         proxy.shutdown().await;
         mock.shutdown().await;


### PR DESCRIPTION
## Summary

Restricts the proxy's phm-token substitution from a blind whole-body / whole-header string-replace to a content-type-aware scope. Closes audit finding **F9** (medium).

- **Headers**: substitute only in a whitelist of auth-bearing names (`Authorization`, `Proxy-Authorization`, `X-API-Key`, `API-Key`, `X-Auth-Token`, `X-Access-Token`, `Cookie`) plus the per-route configured header from `.phantom.toml`.
- **`application/json` bodies** (incl. `application/*+json` and charset variants): parse once, recursively replace phm tokens only inside string values whose parent key is `api_key` / `apikey` / `key` / `token` / `access_token` / `auth_token` / `authorization` / `secret` / `password` (case-insensitive, any depth).
- **Other content-types**: body is forwarded unchanged. Phm tokens seen in unexpected locations emit a `warn!`/`debug!` log (without the value) for auditability.
- Interceptor primitives and response scrubbing are unchanged — scrubbing (real → phm) stays broad on purpose.

## Why

Before this change, a phm substring a user typed into chat message content (e.g. in a `messages[].content` JSON field) would be rewritten to the real secret before being forwarded upstream. The real secret could then land in upstream logs, training data, or abuse reports. The new scope limits substitution to locations where secrets plausibly belong.

## Test plan

- [x] `cargo test -p phantom-proxy` — 41/41 pass
- [x] New `body_scope` unit tests: header allow/deny matrix, content-type detection, allowed/disallowed/nested-allowed JSON fields, malformed JSON, non-JSON content-type, empty body
- [x] New server integration tests: phm in `messages[].content` is NOT substituted upstream; phm in `User-Agent` is NOT substituted
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Pre-existing `test_proxy_replaces_phantom_token_in_body` (`api_key` field) still passes — no regression for the legitimate case

🤖 Generated with [Claude Code](https://claude.com/claude-code)