### PR TITLE
fix(cli): Windows final-mile cleanup — clipboard auto-clear + hook docs (closes #9, #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ set PHANTOM_PROXY_TOKEN=TOKEN
 
 Notes:
 - If `phantom.exe` fails to run with "Application Control policy has blocked this file," Windows Smart App Control is honoring the downloaded file's Mark-of-the-Web tag. One-time fix from PowerShell: `Get-ChildItem "$env:USERPROFILE\.phantom-secrets\bin\*.exe" | Unblock-File`.
-- Clipboard auto-clear (`phantom reveal --copy` clears after 30s) is macOS-only — tracked in [#9](https://github.com/ashlrai/phantom-secrets/issues/9). Clipboard copy itself works on all platforms.
+- The pre-commit hook installed by `phantom init` is a `#!/bin/sh` script. Native git from the command line invokes it via Git for Windows' bundled `sh.exe`, which is what the official Git for Windows installer ships. GUI clients (GitHub Desktop, some IDE integrations) may run with a stripped-down `PATH` that lacks `sh.exe` and silently skip the hook — for these, run commits from a terminal, or use `phantom check --staged` directly. CI is the durable safety net regardless.
 - Windows-on-ARM64 not yet packaged — x64 only. Tracker: [#1](https://github.com/ashlrai/phantom-secrets/issues/1).
 
 ## How It Works

--- a/crates/phantom-cli/src/commands/init/mod.rs
+++ b/crates/phantom-cli/src/commands/init/mod.rs
@@ -186,10 +186,7 @@ fn print_next_steps(config_path: &Path) {
         "Run code with secret injection:",
         "phantom exec -- <your-command>",
     );
-    item(
-        "Verify everything looks healthy:",
-        "phantom doctor",
-    );
+    item("Verify everything looks healthy:", "phantom doctor");
 
     if !logged_in {
         item(
@@ -197,16 +194,10 @@ fn print_next_steps(config_path: &Path) {
             "phantom login",
         );
     } else if !has_cloud_version {
-        item(
-            "Back up this vault to Phantom Cloud:",
-            "phantom cloud push",
-        );
+        item("Back up this vault to Phantom Cloud:", "phantom cloud push");
     }
 
-    item(
-        "Open your dashboard:",
-        "phantom open",
-    );
+    item("Open your dashboard:", "phantom open");
 
     println!();
 }

--- a/crates/phantom-cli/src/commands/open.rs
+++ b/crates/phantom-cli/src/commands/open.rs
@@ -16,9 +16,7 @@ fn resolve_target(target: &str) -> String {
         // Arbitrary URLs are passed through, so `phantom open https://...`
         // works as a shortcut. Anything that doesn't look like a URL falls
         // through to a project-page convention on phm.dev.
-        other if other.starts_with("http://") || other.starts_with("https://") => {
-            other.to_string()
-        }
+        other if other.starts_with("http://") || other.starts_with("https://") => other.to_string(),
         other => format!("https://phm.dev/{}", other.trim_start_matches('/')),
     }
 }
@@ -42,13 +40,22 @@ mod tests {
 
     #[test]
     fn known_aliases_resolve() {
-        assert_eq!(resolve_target("billing"), "https://phm.dev/dashboard/billing");
+        assert_eq!(
+            resolve_target("billing"),
+            "https://phm.dev/dashboard/billing"
+        );
         assert_eq!(resolve_target("team"), "https://phm.dev/dashboard/team");
         assert_eq!(resolve_target("teams"), "https://phm.dev/dashboard/team");
         assert_eq!(resolve_target("docs"), "https://phm.dev/docs");
         assert_eq!(resolve_target("pricing"), "https://phm.dev/pricing");
-        assert_eq!(resolve_target("github"), "https://github.com/ashlrai/phantom-secrets");
-        assert_eq!(resolve_target("issues"), "https://github.com/ashlrai/phantom-secrets/issues");
+        assert_eq!(
+            resolve_target("github"),
+            "https://github.com/ashlrai/phantom-secrets"
+        );
+        assert_eq!(
+            resolve_target("issues"),
+            "https://github.com/ashlrai/phantom-secrets/issues"
+        );
         assert_eq!(resolve_target("site"), "https://phm.dev");
     }
 

--- a/crates/phantom-cli/src/commands/reveal.rs
+++ b/crates/phantom-cli/src/commands/reveal.rs
@@ -48,14 +48,7 @@ pub fn run(name: &str, clipboard: bool, yes: bool) -> Result<()> {
                 "ok".green().bold(),
                 name.bold()
             );
-            #[cfg(target_os = "macos")]
-            {
-                let _ = std::process::Command::new("bash")
-                    .args(["-c", "sleep 30 && echo -n '' | pbcopy"])
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .spawn();
-            }
+            schedule_clipboard_clear(std::time::Duration::from_secs(30));
         } else {
             eprintln!(
                 "{} Clipboard not available. Printing to stdout instead.",
@@ -77,4 +70,39 @@ fn copy_to_clipboard(text: &str) -> bool {
         Ok(mut clipboard) => clipboard.set_text(text.to_string()).is_ok(),
         Err(_) => false,
     }
+}
+
+/// Spawn a detached child of this same binary that sleeps `delay`, then
+/// clears the clipboard. Cross-platform replacement for the macOS-only
+/// `bash -c 'sleep && pbcopy'` shell-out — works on Windows where there's
+/// no bash, and avoids quoting/PATH fragility on Unix.
+///
+/// We spawn a child rather than a thread so the parent `phantom reveal`
+/// process can exit immediately and return the user to their prompt; a
+/// thread would die when the parent exits, and on macOS/Windows the
+/// clipboard contents persist past process exit so we need a live process
+/// to issue the clear.
+fn schedule_clipboard_clear(delay: std::time::Duration) {
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let _ = std::process::Command::new(exe)
+        .arg("__clear-clipboard-after")
+        .arg("--secs")
+        .arg(delay.as_secs().to_string())
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+}
+
+/// Body of the hidden `__clear-clipboard-after` subcommand. Sleeps the
+/// given number of seconds and writes an empty string to the clipboard.
+pub fn run_clear_after(secs: u64) -> Result<()> {
+    std::thread::sleep(std::time::Duration::from_secs(secs));
+    if let Ok(mut cb) = arboard::Clipboard::new() {
+        let _ = cb.set_text(String::new());
+    }
+    Ok(())
 }

--- a/crates/phantom-cli/src/commands/upgrade.rs
+++ b/crates/phantom-cli/src/commands/upgrade.rs
@@ -36,13 +36,23 @@ pub fn run(force: bool, check_only: bool) -> anyhow::Result<()> {
     match update.update() {
         Ok(status) => match status {
             self_update::Status::UpToDate(v) => {
-                println!("{} phantom {} is already at the latest version.", "ok".green().bold(), v);
+                println!(
+                    "{} phantom {} is already at the latest version.",
+                    "ok".green().bold(),
+                    v
+                );
             }
             self_update::Status::Updated(v) => {
-                println!("{} phantom updated to {}.", "ok".green().bold(), v.green().bold());
+                println!(
+                    "{} phantom updated to {}.",
+                    "ok".green().bold(),
+                    v.green().bold()
+                );
             }
         },
-        Err(self_update::errors::Error::Io(e)) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+        Err(self_update::errors::Error::Io(e))
+            if e.kind() == std::io::ErrorKind::PermissionDenied =>
+        {
             println!(
                 "{} Permission denied — if phantom was installed via Homebrew, run: {}",
                 "!".red().bold(),

--- a/crates/phantom-cli/src/main.rs
+++ b/crates/phantom-cli/src/main.rs
@@ -250,6 +250,16 @@ enum Commands {
         #[arg(long)]
         check_only: bool,
     },
+
+    /// Internal: clear the system clipboard after N seconds. Spawned by
+    /// `phantom reveal --copy` so the parent CLI can exit immediately while a
+    /// detached child waits, then clears. Hidden from `--help`.
+    #[command(name = "__clear-clipboard-after", hide = true)]
+    ClearClipboardAfter {
+        /// Seconds to wait before clearing
+        #[arg(long, default_value_t = 30)]
+        secs: u64,
+    },
 }
 
 #[derive(Subcommand)]
@@ -372,6 +382,7 @@ fn main() -> anyhow::Result<()> {
         Commands::Copy { name, to, rename } => commands::copy::run(&name, &to, &rename),
         Commands::Open { target } => commands::open::run(&target),
         Commands::Upgrade { force, check_only } => commands::upgrade::run(force, check_only),
+        Commands::ClearClipboardAfter { secs } => commands::reveal::run_clear_after(secs),
         Commands::Team { action } => match action {
             TeamAction::List => commands::team::run_list(),
             TeamAction::Create { name } => commands::team::run_create(&name),

--- a/crates/phantom-core/src/teams.rs
+++ b/crates/phantom-core/src/teams.rs
@@ -257,9 +257,7 @@ pub async fn pull_team_vault(
 ) -> Result<Option<PulledTeamVault>> {
     let client = reqwest::Client::new();
     let resp = client
-        .get(format!(
-            "{api_base}/teams/{team_id}/vaults/{project_id}"
-        ))
+        .get(format!("{api_base}/teams/{team_id}/vaults/{project_id}"))
         .bearer_auth(token)
         .send()
         .await
@@ -317,9 +315,7 @@ pub async fn push_team_vault(
         key_shares,
     };
     let resp = client
-        .post(format!(
-            "{api_base}/teams/{team_id}/vaults/{project_id}"
-        ))
+        .post(format!("{api_base}/teams/{team_id}/vaults/{project_id}"))
         .bearer_auth(token)
         .json(&body)
         .send()
@@ -354,4 +350,3 @@ pub async fn push_team_vault(
         }
     }
 }
-

--- a/crates/phantom-core/src/teams_vault.rs
+++ b/crates/phantom-core/src/teams_vault.rs
@@ -92,10 +92,8 @@ async fn push_inner(
     teams::register_team_key(api_base, token, team_id, &kp.public_b64()).await?;
 
     let members = teams::list_team_member_keys(api_base, token, team_id).await?;
-    let recipients: Vec<&teams::TeamMemberKey> = members
-        .iter()
-        .filter(|m| m.public_key.is_some())
-        .collect();
+    let recipients: Vec<&teams::TeamMemberKey> =
+        members.iter().filter(|m| m.public_key.is_some()).collect();
     if recipients.is_empty() {
         return Err(PhantomError::Other(format!(
             "No team members have registered public keys yet. \
@@ -196,8 +194,10 @@ pub async fn pull_for_project(
 
     // Move every value into Zeroizing so the secrets are scrubbed when
     // the caller's map is dropped.
-    let secrets: BTreeMap<String, Zeroizing<String>> =
-        raw.into_iter().map(|(k, v)| (k, Zeroizing::new(v))).collect();
+    let secrets: BTreeMap<String, Zeroizing<String>> = raw
+        .into_iter()
+        .map(|(k, v)| (k, Zeroizing::new(v)))
+        .collect();
 
     Ok((secrets, pulled.version))
 }

--- a/crates/phantom-mcp/src/server.rs
+++ b/crates/phantom-mcp/src/server.rs
@@ -1377,14 +1377,13 @@ impl PhantomMcpServer {
     )]
     async fn phantom_team_list(&self) -> Result<CallToolResult, McpError> {
         let token = phantom_core::auth::require_token().map_err(|e| internal_err(e.to_string()))?;
-        let api_base = phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
+        let api_base =
+            phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
         let teams = phantom_core::teams::list_teams(&api_base, &token)
             .await
             .map_err(|e| internal_err(format!("Failed to list teams: {e}")))?;
         if teams.is_empty() {
-            return text_result(
-                "No teams yet. Create one with phantom_team_create.".to_string(),
-            );
+            return text_result("No teams yet. Create one with phantom_team_create.".to_string());
         }
         let mut out = format!("{} team(s):\n", teams.len());
         for t in &teams {
@@ -1403,7 +1402,8 @@ impl PhantomMcpServer {
     ) -> Result<CallToolResult, McpError> {
         require_confirm("phantom_team_create", params.confirm)?;
         let token = phantom_core::auth::require_token().map_err(|e| internal_err(e.to_string()))?;
-        let api_base = phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
+        let api_base =
+            phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
         let team = phantom_core::teams::create_team(&api_base, &token, &params.name)
             .await
             .map_err(|e| internal_err(format!("Failed to create team: {e}")))?;
@@ -1422,16 +1422,23 @@ impl PhantomMcpServer {
         Parameters(params): Parameters<TeamIdParams>,
     ) -> Result<CallToolResult, McpError> {
         let token = phantom_core::auth::require_token().map_err(|e| internal_err(e.to_string()))?;
-        let api_base = phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
+        let api_base =
+            phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
         let members = phantom_core::teams::list_members(&api_base, &token, &params.team_id)
             .await
             .map_err(|e| internal_err(format!("Failed to list members: {e}")))?;
         if members.is_empty() {
-            return text_result("No members yet. Invite someone with phantom_team_invite.".to_string());
+            return text_result(
+                "No members yet. Invite someone with phantom_team_invite.".to_string(),
+            );
         }
         let mut out = format!("{} member(s):\n", members.len());
         for m in &members {
-            let email = m.email.as_deref().map(|e| format!(" <{e}>")).unwrap_or_default();
+            let email = m
+                .email
+                .as_deref()
+                .map(|e| format!(" <{e}>"))
+                .unwrap_or_default();
             out.push_str(&format!("  @{}{} ({})\n", m.github_login, email, m.role));
         }
         text_result(out)
@@ -1453,7 +1460,8 @@ impl PhantomMcpServer {
             )));
         }
         let token = phantom_core::auth::require_token().map_err(|e| internal_err(e.to_string()))?;
-        let api_base = phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
+        let api_base =
+            phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
         phantom_core::teams::invite_member(
             &api_base,
             &token,
@@ -1478,12 +1486,18 @@ impl PhantomMcpServer {
         Parameters(params): Parameters<TeamIdParams>,
     ) -> Result<CallToolResult, McpError> {
         let token = phantom_core::auth::require_token().map_err(|e| internal_err(e.to_string()))?;
-        let api_base = phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
+        let api_base =
+            phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
         let kp = phantom_core::auth::get_or_create_team_keypair()
             .map_err(|e| internal_err(format!("Failed to load team keypair: {e}")))?;
-        phantom_core::teams::register_team_key(&api_base, &token, &params.team_id, &kp.public_b64())
-            .await
-            .map_err(|e| internal_err(format!("Failed to register key: {e}")))?;
+        phantom_core::teams::register_team_key(
+            &api_base,
+            &token,
+            &params.team_id,
+            &kp.public_b64(),
+        )
+        .await
+        .map_err(|e| internal_err(format!("Failed to register key: {e}")))?;
         text_result(format!(
             "Public key registered for team id {}.",
             params.team_id
@@ -1503,7 +1517,8 @@ impl PhantomMcpServer {
         use zeroize::Zeroizing;
 
         let token = phantom_core::auth::require_token().map_err(|e| internal_err(e.to_string()))?;
-        let api_base = phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
+        let api_base =
+            phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
         let kp = phantom_core::auth::get_or_create_team_keypair()
             .map_err(|e| internal_err(format!("Failed to load team keypair: {e}")))?;
 
@@ -1559,7 +1574,8 @@ impl PhantomMcpServer {
     ) -> Result<CallToolResult, McpError> {
         require_confirm("phantom_team_vault_pull", params.confirm)?;
         let token = phantom_core::auth::require_token().map_err(|e| internal_err(e.to_string()))?;
-        let api_base = phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
+        let api_base =
+            phantom_core::auth::api_base_url().map_err(|e| internal_err(e.to_string()))?;
         let kp = phantom_core::auth::get_or_create_team_keypair()
             .map_err(|e| internal_err(format!("Failed to load team keypair: {e}")))?;
 

--- a/crates/phantom-vault/src/file.rs
+++ b/crates/phantom-vault/src/file.rs
@@ -329,7 +329,12 @@ mod tests {
         // Every key must be present and hold the correct value.
         let mut keys = vault.list().unwrap();
         keys.sort();
-        assert_eq!(keys.len(), N, "expected {N} keys, got {}: {keys:?}", keys.len());
+        assert_eq!(
+            keys.len(),
+            N,
+            "expected {N} keys, got {}: {keys:?}",
+            keys.len()
+        );
 
         for i in 0..N {
             let expected = format!("value_{i}");


### PR DESCRIPTION
## Summary

Closes the two remaining functional issues on the Windows tracker (#1):

- **#9** — `phantom reveal --copy` no longer shells out to `bash -c 'sleep 30 && pbcopy'` for the auto-clear. Replaced with a self-respawn of a hidden `phantom __clear-clipboard-after --secs N` subcommand that sleeps and clears via `arboard`. Cross-platform, no shell, preserves the immediate-exit UX of the original (a thread would die when the parent exits, and on macOS/Windows the clipboard persists past process exit — so a live process is needed).
- **#10** — adds a Windows pre-commit hook caveat to the README. The installed `#!/bin/sh` hook works under Git for Windows' bundled `sh.exe` (the standard installer ships it). GUI clients with a stripped `PATH` may silently skip it; recommends terminal commits or `phantom check --staged`, and notes CI as the durable safety net.

After this lands, the only open child of #1 is the umbrella tracker itself — Windows is functionally complete.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check` (on changed files) — clean
- [x] `cargo test --workspace` — all pass except a pre-existing keychain-state-pollution flake unrelated to this change
- [x] `phantom __clear-clipboard-after --secs 1` runs and exits 0
- [x] `phantom --help` does not list the hidden subcommand
- [ ] Manual: `phantom reveal --copy SOME_KEY` returns the prompt immediately, clipboard clears 30s later (Windows + macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)