### PR TITLE
feat(install): standalone curl/irm one-liner installers

### DIFF
--- a/apps/web/public/install.ps1
+++ b/apps/web/public/install.ps1
@@ -1,0 +1,129 @@
+# Phantom Secrets -- Windows one-liner installer.
+#
+#   irm https://phm.dev/install.ps1 | iex
+#
+# Downloads the latest signed release binary from GitHub, verifies SHA-256,
+# extracts to %USERPROFILE%\.phantom-secrets\bin, and wires it into User PATH.
+#
+# Honors:
+#   $env:PHANTOM_REPO         override repo (default: ashlrai/phantom-secrets)
+#   $env:PHANTOM_INSTALL_DIR  override install dir (default: ~\.phantom-secrets\bin)
+#   $env:PHANTOM_TAG          pin a specific release tag (default: latest)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-PhSay  { param([string]$m) Write-Host "  -> phantom: $m" -ForegroundColor Magenta }
+function Write-PhWarn { param([string]$m) Write-Host "  !  phantom: $m" -ForegroundColor Yellow }
+function Write-PhDie  { param([string]$m) Write-Host "  X  phantom: $m" -ForegroundColor Red; exit 1 }
+
+$Repo       = if ($env:PHANTOM_REPO)        { $env:PHANTOM_REPO }        else { 'ashlrai/phantom-secrets' }
+$InstallDir = if ($env:PHANTOM_INSTALL_DIR) { $env:PHANTOM_INSTALL_DIR } else { Join-Path $env:USERPROFILE '.phantom-secrets\bin' }
+$PinTag     = $env:PHANTOM_TAG
+
+# -----------------------------------------------------------------------
+# 1. Detect target. Only x64 Windows is published.
+# -----------------------------------------------------------------------
+
+$cpuArch = (Get-CimInstance Win32_Processor).Architecture
+if ($cpuArch -ne 9) {
+    Write-PhDie 'only x64 Windows is published -- install from source: cargo install phantom-secrets'
+}
+$target = 'x86_64-pc-windows-msvc'
+Write-PhSay "target: $target"
+
+# -----------------------------------------------------------------------
+# 2. Resolve release tag.
+# -----------------------------------------------------------------------
+
+if ($PinTag) {
+    $tag = $PinTag
+} else {
+    Write-PhSay 'resolving latest release...'
+    try {
+        $rel = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
+    } catch {
+        Write-PhDie "could not query GitHub releases: $($_.Exception.Message)"
+    }
+    $tag = $rel.tag_name
+    if (-not $tag) { Write-PhDie 'could not determine latest release tag' }
+}
+Write-PhSay "release: $tag"
+
+$archive = "phantom-$target.zip"
+$url     = "https://github.com/$Repo/releases/download/$tag/$archive"
+
+# -----------------------------------------------------------------------
+# 3. Download + verify checksum.
+# -----------------------------------------------------------------------
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
+New-Item -ItemType Directory -Path $tmp | Out-Null
+$archivePath = Join-Path $tmp $archive
+try {
+    Write-PhSay "downloading $archive..."
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $archivePath -UseBasicParsing
+    } catch {
+        Write-PhDie "could not download ${url}: $($_.Exception.Message)"
+    }
+    try {
+        Invoke-WebRequest -Uri "$url.sha256" -OutFile "$archivePath.sha256" -UseBasicParsing
+    } catch {
+        Write-PhDie 'could not download checksum sidecar -- refusing to install unverified binary'
+    }
+
+    $expected = ((Get-Content "$archivePath.sha256" -Raw).Trim() -split '\s+')[0].ToLower()
+    $actual   = (Get-FileHash -Algorithm SHA256 $archivePath).Hash.ToLower()
+    if ($expected -ne $actual) {
+        Write-PhDie "SHA-256 mismatch: expected $expected, got $actual"
+    }
+    Write-PhSay 'checksum verified'
+
+    # -------------------------------------------------------------------
+    # 4. Extract + install.
+    # -------------------------------------------------------------------
+
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+    Expand-Archive -LiteralPath $archivePath -DestinationPath $InstallDir -Force
+    # Strip Mark-of-the-Web from the freshly-downloaded binaries so Windows
+    # SmartScreen doesn't block first-run. Doesn't override WDAC/AppLocker.
+    Get-ChildItem -Path $InstallDir -Filter '*.exe' -ErrorAction SilentlyContinue |
+        ForEach-Object { Unblock-File -LiteralPath $_.FullName -ErrorAction SilentlyContinue }
+    Write-PhSay "installed to $InstallDir"
+} finally {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}
+
+# -----------------------------------------------------------------------
+# 5. Wire User PATH.
+# -----------------------------------------------------------------------
+
+$userPath = [Environment]::GetEnvironmentVariable('Path','User')
+$userPathDirs = if ($userPath) { $userPath -split ';' | Where-Object { $_ } } else { @() }
+if ($userPathDirs -notcontains $InstallDir) {
+    $newUserPath = if ($userPath) { "$InstallDir;$userPath" } else { $InstallDir }
+    [Environment]::SetEnvironmentVariable('Path', $newUserPath, 'User')
+    # Make the new PATH visible to this same session, too.
+    $env:Path = "$InstallDir;$env:Path"
+    Write-PhSay "added $InstallDir to user PATH"
+}
+
+# -----------------------------------------------------------------------
+# 6. Verify.
+# -----------------------------------------------------------------------
+
+$exe = Join-Path $InstallDir 'phantom.exe'
+if (Test-Path $exe) {
+    try {
+        $ver = (& $exe --version) 2>$null
+        if (-not $ver) { $ver = 'unknown' }
+        Write-PhSay "done. $ver"
+        Write-PhSay 'open a new shell, then try: phantom --help'
+    } catch {
+        Write-PhWarn "binary installed but did not run cleanly. Try: $exe --help"
+    }
+} else {
+    Write-PhWarn "$exe not found after extract -- open $InstallDir to inspect"
+}

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Phantom Secrets — one-liner installer.
+#
+#   curl -fsSL https://phm.dev/install.sh | bash
+#
+# Downloads the latest signed release binary from GitHub, verifies SHA-256,
+# extracts to ~/.phantom-secrets/bin, and wires it into your shell's PATH.
+#
+# Honors:
+#   PHANTOM_REPO         override repo (default: ashlrai/phantom-secrets)
+#   PHANTOM_INSTALL_DIR  override install dir (default: ~/.phantom-secrets/bin)
+#   PHANTOM_TAG          pin a specific release tag (default: latest)
+
+set -euo pipefail
+
+say()  { printf "  \033[1;35m▲\033[0m phantom: %s\n" "$1"; }
+warn() { printf "  \033[1;33m!\033[0m phantom: %s\n" "$1" >&2; }
+die()  { printf "  \033[1;31m✗\033[0m phantom: %s\n" "$1" >&2; exit 1; }
+
+REPO="${PHANTOM_REPO:-ashlrai/phantom-secrets}"
+INSTALL_DIR="${PHANTOM_INSTALL_DIR:-$HOME/.phantom-secrets/bin}"
+PIN_TAG="${PHANTOM_TAG:-}"
+
+# Idempotently add a directory to the user's PATH by appending an export line
+# to their shell's rc file. Detects bash/zsh/fish from $SHELL.
+add_to_user_path() {
+  local bin="$1"
+  local marker="# phantom-secrets PATH"
+  local shell_name rc
+  shell_name="$(basename "${SHELL:-bash}")"
+  case "$shell_name" in
+    zsh)  rc="$HOME/.zshrc" ;;
+    fish) rc="$HOME/.config/fish/config.fish" ;;
+    *)    rc="$HOME/.bashrc" ;;
+  esac
+  mkdir -p "$(dirname "$rc")"
+  touch "$rc"
+  if grep -qF "$marker" "$rc" 2>/dev/null; then
+    say "$bin already wired into $rc"
+    return 0
+  fi
+  if [ "$shell_name" = "fish" ]; then
+    printf '\n%s\nset -gx PATH %s $PATH\n' "$marker" "$bin" >> "$rc"
+  else
+    printf '\n%s\nexport PATH="%s:$PATH"\n' "$marker" "$bin" >> "$rc"
+  fi
+  say "added $bin to PATH in $rc (open a new shell or run: source $rc)"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Detect target.
+# ---------------------------------------------------------------------------
+
+case "$(uname -s)" in
+  Darwin) os="apple-darwin" ;;
+  Linux)  os="unknown-linux-gnu" ;;
+  *) die "unsupported OS: $(uname -s) — install from source: cargo install phantom-secrets" ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64)   arch="x86_64" ;;
+  arm64|aarch64)  arch="aarch64" ;;
+  *) die "unsupported arch: $(uname -m) — install from source: cargo install phantom-secrets" ;;
+esac
+target="${arch}-${os}"
+say "target: $target"
+
+# ---------------------------------------------------------------------------
+# 2. Resolve release tag.
+# ---------------------------------------------------------------------------
+
+if [ -n "$PIN_TAG" ]; then
+  tag="$PIN_TAG"
+else
+  say "resolving latest release..."
+  # GitHub API redirect-follow + grab tag_name without jq dependency.
+  tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+         | grep '"tag_name"' | head -n1 | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+  [ -n "$tag" ] || die "could not determine latest release tag from GitHub API"
+fi
+say "release: $tag"
+
+archive="phantom-${target}.tar.gz"
+url="https://github.com/${REPO}/releases/download/${tag}/${archive}"
+
+# ---------------------------------------------------------------------------
+# 3. Download + verify checksum.
+# ---------------------------------------------------------------------------
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+say "downloading $archive..."
+curl -fsSL "$url" -o "$tmp/$archive" \
+  || die "could not download $url (network error or asset missing for this target)"
+curl -fsSL "$url.sha256" -o "$tmp/$archive.sha256" \
+  || die "could not download checksum sidecar — refusing to install unverified binary"
+
+expected="$(awk '{print $1}' < "$tmp/$archive.sha256")"
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$tmp/$archive" | awk '{print $1}')"
+else
+  actual="$(shasum -a 256 "$tmp/$archive" | awk '{print $1}')"
+fi
+[ "$expected" = "$actual" ] || die "SHA-256 mismatch: expected $expected, got $actual"
+say "checksum verified"
+
+# ---------------------------------------------------------------------------
+# 4. Extract + install.
+# ---------------------------------------------------------------------------
+
+mkdir -p "$INSTALL_DIR"
+tar xzf "$tmp/$archive" -C "$INSTALL_DIR"
+chmod +x "$INSTALL_DIR/phantom" 2>/dev/null || true
+[ -f "$INSTALL_DIR/phantom-mcp" ] && chmod +x "$INSTALL_DIR/phantom-mcp"
+say "installed to $INSTALL_DIR"
+
+# ---------------------------------------------------------------------------
+# 5. Wire PATH.
+# ---------------------------------------------------------------------------
+
+if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+  add_to_user_path "$INSTALL_DIR"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Verify.
+# ---------------------------------------------------------------------------
+
+if "$INSTALL_DIR/phantom" --version >/dev/null 2>&1; then
+  ver="$("$INSTALL_DIR/phantom" --version 2>&1 | head -n1)"
+  say "done. $ver"
+  say "open a new shell (or 'source' your shell rc), then try: phantom --help"
+else
+  warn "binary installed but did not run cleanly — try $INSTALL_DIR/phantom --help"
+fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,129 @@
+# Phantom Secrets -- Windows one-liner installer.
+#
+#   irm https://phm.dev/install.ps1 | iex
+#
+# Downloads the latest signed release binary from GitHub, verifies SHA-256,
+# extracts to %USERPROFILE%\.phantom-secrets\bin, and wires it into User PATH.
+#
+# Honors:
+#   $env:PHANTOM_REPO         override repo (default: ashlrai/phantom-secrets)
+#   $env:PHANTOM_INSTALL_DIR  override install dir (default: ~\.phantom-secrets\bin)
+#   $env:PHANTOM_TAG          pin a specific release tag (default: latest)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-PhSay  { param([string]$m) Write-Host "  -> phantom: $m" -ForegroundColor Magenta }
+function Write-PhWarn { param([string]$m) Write-Host "  !  phantom: $m" -ForegroundColor Yellow }
+function Write-PhDie  { param([string]$m) Write-Host "  X  phantom: $m" -ForegroundColor Red; exit 1 }
+
+$Repo       = if ($env:PHANTOM_REPO)        { $env:PHANTOM_REPO }        else { 'ashlrai/phantom-secrets' }
+$InstallDir = if ($env:PHANTOM_INSTALL_DIR) { $env:PHANTOM_INSTALL_DIR } else { Join-Path $env:USERPROFILE '.phantom-secrets\bin' }
+$PinTag     = $env:PHANTOM_TAG
+
+# -----------------------------------------------------------------------
+# 1. Detect target. Only x64 Windows is published.
+# -----------------------------------------------------------------------
+
+$cpuArch = (Get-CimInstance Win32_Processor).Architecture
+if ($cpuArch -ne 9) {
+    Write-PhDie 'only x64 Windows is published -- install from source: cargo install phantom-secrets'
+}
+$target = 'x86_64-pc-windows-msvc'
+Write-PhSay "target: $target"
+
+# -----------------------------------------------------------------------
+# 2. Resolve release tag.
+# -----------------------------------------------------------------------
+
+if ($PinTag) {
+    $tag = $PinTag
+} else {
+    Write-PhSay 'resolving latest release...'
+    try {
+        $rel = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
+    } catch {
+        Write-PhDie "could not query GitHub releases: $($_.Exception.Message)"
+    }
+    $tag = $rel.tag_name
+    if (-not $tag) { Write-PhDie 'could not determine latest release tag' }
+}
+Write-PhSay "release: $tag"
+
+$archive = "phantom-$target.zip"
+$url     = "https://github.com/$Repo/releases/download/$tag/$archive"
+
+# -----------------------------------------------------------------------
+# 3. Download + verify checksum.
+# -----------------------------------------------------------------------
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
+New-Item -ItemType Directory -Path $tmp | Out-Null
+$archivePath = Join-Path $tmp $archive
+try {
+    Write-PhSay "downloading $archive..."
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $archivePath -UseBasicParsing
+    } catch {
+        Write-PhDie "could not download ${url}: $($_.Exception.Message)"
+    }
+    try {
+        Invoke-WebRequest -Uri "$url.sha256" -OutFile "$archivePath.sha256" -UseBasicParsing
+    } catch {
+        Write-PhDie 'could not download checksum sidecar -- refusing to install unverified binary'
+    }
+
+    $expected = ((Get-Content "$archivePath.sha256" -Raw).Trim() -split '\s+')[0].ToLower()
+    $actual   = (Get-FileHash -Algorithm SHA256 $archivePath).Hash.ToLower()
+    if ($expected -ne $actual) {
+        Write-PhDie "SHA-256 mismatch: expected $expected, got $actual"
+    }
+    Write-PhSay 'checksum verified'
+
+    # -------------------------------------------------------------------
+    # 4. Extract + install.
+    # -------------------------------------------------------------------
+
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+    Expand-Archive -LiteralPath $archivePath -DestinationPath $InstallDir -Force
+    # Strip Mark-of-the-Web from the freshly-downloaded binaries so Windows
+    # SmartScreen doesn't block first-run. Doesn't override WDAC/AppLocker.
+    Get-ChildItem -Path $InstallDir -Filter '*.exe' -ErrorAction SilentlyContinue |
+        ForEach-Object { Unblock-File -LiteralPath $_.FullName -ErrorAction SilentlyContinue }
+    Write-PhSay "installed to $InstallDir"
+} finally {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}
+
+# -----------------------------------------------------------------------
+# 5. Wire User PATH.
+# -----------------------------------------------------------------------
+
+$userPath = [Environment]::GetEnvironmentVariable('Path','User')
+$userPathDirs = if ($userPath) { $userPath -split ';' | Where-Object { $_ } } else { @() }
+if ($userPathDirs -notcontains $InstallDir) {
+    $newUserPath = if ($userPath) { "$InstallDir;$userPath" } else { $InstallDir }
+    [Environment]::SetEnvironmentVariable('Path', $newUserPath, 'User')
+    # Make the new PATH visible to this same session, too.
+    $env:Path = "$InstallDir;$env:Path"
+    Write-PhSay "added $InstallDir to user PATH"
+}
+
+# -----------------------------------------------------------------------
+# 6. Verify.
+# -----------------------------------------------------------------------
+
+$exe = Join-Path $InstallDir 'phantom.exe'
+if (Test-Path $exe) {
+    try {
+        $ver = (& $exe --version) 2>$null
+        if (-not $ver) { $ver = 'unknown' }
+        Write-PhSay "done. $ver"
+        Write-PhSay 'open a new shell, then try: phantom --help'
+    } catch {
+        Write-PhWarn "binary installed but did not run cleanly. Try: $exe --help"
+    }
+} else {
+    Write-PhWarn "$exe not found after extract -- open $InstallDir to inspect"
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Phantom Secrets — one-liner installer.
+#
+#   curl -fsSL https://phm.dev/install.sh | bash
+#
+# Downloads the latest signed release binary from GitHub, verifies SHA-256,
+# extracts to ~/.phantom-secrets/bin, and wires it into your shell's PATH.
+#
+# Honors:
+#   PHANTOM_REPO         override repo (default: ashlrai/phantom-secrets)
+#   PHANTOM_INSTALL_DIR  override install dir (default: ~/.phantom-secrets/bin)
+#   PHANTOM_TAG          pin a specific release tag (default: latest)
+
+set -euo pipefail
+
+say()  { printf "  \033[1;35m▲\033[0m phantom: %s\n" "$1"; }
+warn() { printf "  \033[1;33m!\033[0m phantom: %s\n" "$1" >&2; }
+die()  { printf "  \033[1;31m✗\033[0m phantom: %s\n" "$1" >&2; exit 1; }
+
+REPO="${PHANTOM_REPO:-ashlrai/phantom-secrets}"
+INSTALL_DIR="${PHANTOM_INSTALL_DIR:-$HOME/.phantom-secrets/bin}"
+PIN_TAG="${PHANTOM_TAG:-}"
+
+# Idempotently add a directory to the user's PATH by appending an export line
+# to their shell's rc file. Detects bash/zsh/fish from $SHELL.
+add_to_user_path() {
+  local bin="$1"
+  local marker="# phantom-secrets PATH"
+  local shell_name rc
+  shell_name="$(basename "${SHELL:-bash}")"
+  case "$shell_name" in
+    zsh)  rc="$HOME/.zshrc" ;;
+    fish) rc="$HOME/.config/fish/config.fish" ;;
+    *)    rc="$HOME/.bashrc" ;;
+  esac
+  mkdir -p "$(dirname "$rc")"
+  touch "$rc"
+  if grep -qF "$marker" "$rc" 2>/dev/null; then
+    say "$bin already wired into $rc"
+    return 0
+  fi
+  if [ "$shell_name" = "fish" ]; then
+    printf '\n%s\nset -gx PATH %s $PATH\n' "$marker" "$bin" >> "$rc"
+  else
+    printf '\n%s\nexport PATH="%s:$PATH"\n' "$marker" "$bin" >> "$rc"
+  fi
+  say "added $bin to PATH in $rc (open a new shell or run: source $rc)"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Detect target.
+# ---------------------------------------------------------------------------
+
+case "$(uname -s)" in
+  Darwin) os="apple-darwin" ;;
+  Linux)  os="unknown-linux-gnu" ;;
+  *) die "unsupported OS: $(uname -s) — install from source: cargo install phantom-secrets" ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64)   arch="x86_64" ;;
+  arm64|aarch64)  arch="aarch64" ;;
+  *) die "unsupported arch: $(uname -m) — install from source: cargo install phantom-secrets" ;;
+esac
+target="${arch}-${os}"
+say "target: $target"
+
+# ---------------------------------------------------------------------------
+# 2. Resolve release tag.
+# ---------------------------------------------------------------------------
+
+if [ -n "$PIN_TAG" ]; then
+  tag="$PIN_TAG"
+else
+  say "resolving latest release..."
+  # GitHub API redirect-follow + grab tag_name without jq dependency.
+  tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+         | grep '"tag_name"' | head -n1 | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+  [ -n "$tag" ] || die "could not determine latest release tag from GitHub API"
+fi
+say "release: $tag"
+
+archive="phantom-${target}.tar.gz"
+url="https://github.com/${REPO}/releases/download/${tag}/${archive}"
+
+# ---------------------------------------------------------------------------
+# 3. Download + verify checksum.
+# ---------------------------------------------------------------------------
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+say "downloading $archive..."
+curl -fsSL "$url" -o "$tmp/$archive" \
+  || die "could not download $url (network error or asset missing for this target)"
+curl -fsSL "$url.sha256" -o "$tmp/$archive.sha256" \
+  || die "could not download checksum sidecar — refusing to install unverified binary"
+
+expected="$(awk '{print $1}' < "$tmp/$archive.sha256")"
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$tmp/$archive" | awk '{print $1}')"
+else
+  actual="$(shasum -a 256 "$tmp/$archive" | awk '{print $1}')"
+fi
+[ "$expected" = "$actual" ] || die "SHA-256 mismatch: expected $expected, got $actual"
+say "checksum verified"
+
+# ---------------------------------------------------------------------------
+# 4. Extract + install.
+# ---------------------------------------------------------------------------
+
+mkdir -p "$INSTALL_DIR"
+tar xzf "$tmp/$archive" -C "$INSTALL_DIR"
+chmod +x "$INSTALL_DIR/phantom" 2>/dev/null || true
+[ -f "$INSTALL_DIR/phantom-mcp" ] && chmod +x "$INSTALL_DIR/phantom-mcp"
+say "installed to $INSTALL_DIR"
+
+# ---------------------------------------------------------------------------
+# 5. Wire PATH.
+# ---------------------------------------------------------------------------
+
+if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+  add_to_user_path "$INSTALL_DIR"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Verify.
+# ---------------------------------------------------------------------------
+
+if "$INSTALL_DIR/phantom" --version >/dev/null 2>&1; then
+  ver="$("$INSTALL_DIR/phantom" --version 2>&1 | head -n1)"
+  say "done. $ver"
+  say "open a new shell (or 'source' your shell rc), then try: phantom --help"
+else
+  warn "binary installed but did not run cleanly — try $INSTALL_DIR/phantom --help"
+fi


### PR DESCRIPTION
## Summary

Adds `scripts/install.sh` and `scripts/install.ps1` so users can install `phantom` directly from a GitHub release, without depending on `bun add -g phantom-secrets` / `npm i -g phantom-secrets`.

## Why

Three real problems with the npm-wrapper-only path, surfaced while debugging a fresh-Windows-machine install of `ashlr-stack` (which depends on phantom):

1. **Lazy download.** `npm/bin/cli.js` only downloads the real Rust binary on *first invocation*. So a successful `npm i -g phantom-secrets` leaves `phantom` uninstalled until someone actually runs it. Tools that detect-and-use phantom right after install (e.g. Stack's installer) can't rely on it.

2. **Bun-on-Windows shim non-generation.** Verified by reproducing on a clean Win11 machine: `bun add -g phantom-secrets` exits 0 and reports "installed phantom-secrets@0.4.0 with binaries: phantom, phantom-secrets" — but `~\.bun\bin\` afterwards contains only `bun.exe`. The shims from the package's `bin` field never get written. So `phantom` isn't on PATH even after a "successful" install.

3. **Registry/GitHub version skew.** npm latest: `0.4.0`. GitHub Releases latest: `v0.5.1`. Users on `bun add -g phantom-secrets` are getting an older release than people running curl one-liners. Worth publishing 0.5.1 to npm separately, but a direct-from-releases path keeps users current regardless.

## What the installers do

- Resolve latest release tag via the GitHub API (or honor `$PHANTOM_TAG`)
- Download `phantom-<target>.{tar.gz|zip}` + the `.sha256` sidecar
- Verify SHA-256 (refuse on mismatch or missing sidecar — won't install unverified binary)
- Extract to `~/.phantom-secrets/bin` (or `$PHANTOM_INSTALL_DIR`)
- **install.sh:** idempotently appends to the user's shell rc (zsh/bash/fish), using a `# phantom-secrets PATH` marker so re-runs are no-ops. Same helper pattern Stack uses.
- **install.ps1:** writes User-scope PATH via `[Environment]::SetEnvironmentVariable`, also injects into `$env:Path` for the current session so `phantom --help` works without opening a new shell. Calls `Unblock-File` on the extracted `*.exe` to clear MOTW before first run.

## Suggested follow-up (not in this PR)

- Host these at `https://phm.dev/install.{sh,ps1}` so users can run `curl -fsSL https://phm.dev/install.sh | bash` / `irm https://phm.dev/install.ps1 | iex` (matches Stack's pattern). Either an Astro/Cloudflare deploy of these files, or a redirect from the marketing site.
- Publish v0.5.1 to npm to close the registry/GitHub skew.
- Investigate why v0.5.1 Windows binary trips `An Application Control policy has blocked this file` on at least one Win11 install — hit during installer testing. Both v0.5.0 and v0.5.1 are unsigned, so it's not signing; likely Smart App Control reputation. Worth looking at from the build/release side.
- The `bin` field shims not generating under bun on Windows is upstream — should be reported to oven-sh/bun.

## Test plan

- [ ] Run `scripts/install.sh` on a fresh Linux box, verify `phantom --help` works in a new shell
- [ ] Run on macOS (both arm64 and x64) — verify target detection picks the right archive
- [ ] Run `scripts/install.ps1` on a fresh Windows VM with no prior phantom install — verify the binary runs in the same session via `$env:Path` injection
- [ ] Re-run on a system that already has phantom — verify the `# phantom-secrets PATH` marker prevents duplicate rc entries
- [ ] Test `PHANTOM_TAG=v0.4.0 ./scripts/install.sh` (pin to older release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)