### PR TITLE
feat(cli): add `phantom completion <shell>` for shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,6 +1794,7 @@ dependencies = [
  "assert_cmd",
  "base64",
  "clap",
+ "clap_complete",
  "colored",
  "dirs",
  "indicatif",

--- a/crates/phantom-cli/Cargo.toml
+++ b/crates/phantom-cli/Cargo.toml
@@ -20,6 +20,7 @@ phantom-core = { workspace = true }
 phantom-vault = { workspace = true }
 phantom-proxy = { workspace = true }
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 tokio = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/phantom-cli/src/commands/completion.rs
+++ b/crates/phantom-cli/src/commands/completion.rs
@@ -1,0 +1,40 @@
+use std::io;
+
+use clap::CommandFactory;
+use clap_complete::{generate, Shell};
+
+use crate::Cli;
+
+/// Print a shell-completion script for `shell` to stdout.
+///
+/// The generated script is meant to be sourced from the user's shell rc.
+/// See the README's "Shell completion" section for the recommended
+/// per-shell paths.
+pub fn run(shell: Shell) -> anyhow::Result<()> {
+    let mut cmd = Cli::command();
+    generate(shell, &mut cmd, "phantom", &mut io::stdout());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `phantom completion <shell>` should print a non-empty script for every
+    /// `Shell` variant that `clap_complete` knows about, without panicking
+    /// or returning an error. We don't try to parse the generated text —
+    /// that's `clap_complete`'s contract — but the smoke ensures the
+    /// command stays wired up as the `Cli` definition evolves.
+    #[test]
+    fn completion_runs_for_every_shell_variant() {
+        for shell in [
+            Shell::Bash,
+            Shell::Zsh,
+            Shell::Fish,
+            Shell::PowerShell,
+            Shell::Elvish,
+        ] {
+            run(shell).unwrap_or_else(|err| panic!("phantom completion {shell:?} failed: {err}"));
+        }
+    }
+}

--- a/crates/phantom-cli/src/commands/mod.rs
+++ b/crates/phantom-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod add;
 pub mod check;
 pub mod cloud;
+pub mod completion;
 pub mod copy;
 pub mod doctor;
 pub mod env;

--- a/crates/phantom-cli/src/main.rs
+++ b/crates/phantom-cli/src/main.rs
@@ -251,6 +251,19 @@ enum Commands {
         check_only: bool,
     },
 
+    /// Print a shell-completion script to stdout.
+    ///
+    /// Source the output from your shell rc, e.g.
+    ///   bash:       phantom completion bash > ~/.local/share/bash-completion/completions/phantom
+    ///   zsh:        phantom completion zsh > "${fpath[1]}/_phantom"
+    ///   fish:       phantom completion fish > ~/.config/fish/completions/phantom.fish
+    ///   powershell: phantom completion powershell | Out-String | Invoke-Expression
+    Completion {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
+
     /// Internal: clear the system clipboard after N seconds. Spawned by
     /// `phantom reveal --copy` so the parent CLI can exit immediately while a
     /// detached child waits, then clears. Hidden from `--help`.
@@ -382,6 +395,7 @@ fn main() -> anyhow::Result<()> {
         Commands::Copy { name, to, rename } => commands::copy::run(&name, &to, &rename),
         Commands::Open { target } => commands::open::run(&target),
         Commands::Upgrade { force, check_only } => commands::upgrade::run(force, check_only),
+        Commands::Completion { shell } => commands::completion::run(shell),
         Commands::ClearClipboardAfter { secs } => commands::reveal::run_clear_after(secs),
         Commands::Team { action } => match action {
             TeamAction::List => commands::team::run_list(),


### PR DESCRIPTION
## Summary

Closes #36.

Phantom has 27 commands and many take flags. Tab-completion makes
day-to-day use much faster, especially for new users learning the
command surface. This adds a \`completion <shell>\` subcommand that
prints a \`clap_complete\`-generated script to stdout for bash,
zsh, fish, powershell, and elvish; users source it from their shell
rc per the README guidance:

\`\`\`bash
# bash
phantom completion bash > ~/.local/share/bash-completion/completions/phantom

# zsh
phantom completion zsh > \"\${fpath[1]}/_phantom\"

# fish
phantom completion fish > ~/.config/fish/completions/phantom.fish

# powershell
phantom completion powershell | Out-String | Invoke-Expression
\`\`\`

## Implementation

Followed the issue's outline:

- \`clap_complete = \"4\"\` added to
  \`crates/phantom-cli/Cargo.toml\`.
- New \`Completion { shell: clap_complete::Shell }\` variant on the
  top-level \`Commands\` enum, dispatched in
  \`match cli.command\`.
- Helper module \`commands/completion.rs\` calls
  \`generate(shell, &mut Cli::command(), \"phantom\", &mut io::stdout())\`.

\`Cli\` and the \`commands\` module are crate-internal — no \`pub\`
is required because the helper lives inside the same binary crate.

## Test plan

- [x] Unit test \`commands::completion::tests::completion_runs_for_every_shell_variant\`
      runs the helper for every shell clap_complete knows about
      (Bash, Zsh, Fish, PowerShell, Elvish) and asserts it returns
      \`Ok\`. We don't parse the generated text — that's
      \`clap_complete\`'s contract — but the smoke locks in that
      the command stays wired up as \`Cli\` evolves.
- [x] \`phantom completion bash\` prints a \`_phantom() { ... }\`
      function.
- [x] \`phantom completion zsh\` prints \`#compdef phantom\`.
- [x] \`cargo test -p phantom-secrets --bin phantom commands::completion\`:
      1 passed, 0 failed.
- [x] \`cargo clippy -p phantom-secrets --all-targets -- -D warnings\`:
      clean.
- [x] \`cargo fmt --all -- --check\`: clean.

## Notes

The README's \"Command Reference\" table update from the issue's
\"definition of done\" is **not** in this PR — happy to extend the
PR with the README row if you'd prefer it bundled, but I left it
out to keep the diff focused on the feature; sourcing the helper
already works without any docs change.