### PR TITLE
feat(core): preserve quotes/indent/export prefix when phantom-tokenizing .env

### DIFF
--- a/crates/phantom-core/src/dotenv.rs
+++ b/crates/phantom-core/src/dotenv.rs
@@ -102,7 +102,10 @@ impl DotenvFile {
                 continue;
             }
 
-            let working = trimmed.strip_prefix("export ").unwrap_or(trimmed);
+            let (working, had_export) = match trimmed.strip_prefix("export ") {
+                Some(rest) => (rest, true),
+                None => (trimmed, false),
+            };
             let Some(eq_pos) = working.find('=') else {
                 out.push(DotenvLine::Other(line.to_string()));
                 continue;
@@ -114,15 +117,20 @@ impl DotenvFile {
                 continue;
             }
 
-            let raw_value = working[eq_pos + 1..].trim_start();
+            let after_eq = &working[eq_pos + 1..];
+            let raw_value = after_eq.trim_start();
 
-            // Track byte offsets in the original `line` so we can splice a
+            // Compute byte offsets in the original `line` so we can splice a
             // replacement value while preserving the surrounding format.
+            // Derived from known structure (leading whitespace + optional
+            // 7-byte "export " prefix) rather than a substring search.
             // Computed unconditionally; consumed only if parsing stays on a
             // single line and produces no embedded escapes.
-            let working_offset = line.find(working).unwrap_or(0);
+            let leading_ws = line.len() - line.trim_start().len();
+            let working_offset = leading_ws + if had_export { "export ".len() } else { 0 };
             let eq_in_line = working_offset + eq_pos;
-            let raw_value_offset = eq_in_line + 1 + (working[eq_pos + 1..].len() - raw_value.len());
+            let ws_after_eq = after_eq.len() - raw_value.len();
+            let raw_value_offset = eq_in_line + 1 + ws_after_eq;
 
             let (value, fmt) = if let Some(after_quote) = raw_value.strip_prefix('"') {
                 // Double-quoted — may span multiple lines (F12).
@@ -189,12 +197,28 @@ impl DotenvFile {
                     }
                 }
             } else {
+                // Unquoted: convention is that `#` preceded by whitespace
+                // starts an inline comment. Strip it from the stored value
+                // (otherwise the comment would be injected as part of the
+                // secret on outbound requests) but keep it in the raw line
+                // so format preservation can splice the new value in front
+                // of it.
+                let comment_offset = raw_value
+                    .char_indices()
+                    .find(|(i, c)| {
+                        *c == '#' && *i > 0 && raw_value.as_bytes()[*i - 1].is_ascii_whitespace()
+                    })
+                    .map(|(i, _)| i);
+                let value_text = match comment_offset {
+                    Some(i) => raw_value[..i].trim_end(),
+                    None => raw_value.trim_end(),
+                };
                 let fmt = Some(RawLineFormat {
                     raw: line.to_string(),
                     value_start: raw_value_offset,
-                    value_end: raw_value_offset + raw_value.len(),
+                    value_end: raw_value_offset + value_text.len(),
                 });
-                (raw_value.to_string(), fmt)
+                (value_text.to_string(), fmt)
             };
 
             out.push(DotenvLine::Entry(
@@ -1000,49 +1024,54 @@ KEY3=unquoted
     /// Format preservation: when a value gets a phantom token, the surrounding
     /// quotes/whitespace/`export` prefix on the same line should survive.
     /// Verifies the splice path rather than the canonical reformat path.
-    fn token_map_for(key: &str, token: &str) -> TokenMap {
+    fn assert_rewrite(key: &str, token: &str, input: &str, expected: &str) {
         let mut tm = TokenMap::new();
         tm.insert_with_token(
             key.to_string(),
             PhantomToken::parse(token).expect("test token must start with phm_"),
         );
-        tm
+        let (out, _) = DotenvFile::parse_str(input).rewrite_with_phantoms(&tm);
+        assert_eq!(out, expected);
     }
 
     #[test]
     fn rewrite_preserves_double_quotes() {
-        let content = "API_KEY=\"sk-real-test\"\n";
-        let dotenv = DotenvFile::parse_str(content);
-        let tm = token_map_for("API_KEY", "phm_aaaa");
-        let (out, _) = dotenv.rewrite_with_phantoms(&tm);
-        assert_eq!(out, "API_KEY=\"phm_aaaa\"\n");
+        assert_rewrite(
+            "API_KEY",
+            "phm_aaaa",
+            "API_KEY=\"sk-real-test\"\n",
+            "API_KEY=\"phm_aaaa\"\n",
+        );
     }
 
     #[test]
     fn rewrite_preserves_single_quotes() {
-        let content = "API_KEY='sk-real-test'\n";
-        let dotenv = DotenvFile::parse_str(content);
-        let tm = token_map_for("API_KEY", "phm_bbbb");
-        let (out, _) = dotenv.rewrite_with_phantoms(&tm);
-        assert_eq!(out, "API_KEY='phm_bbbb'\n");
+        assert_rewrite(
+            "API_KEY",
+            "phm_bbbb",
+            "API_KEY='sk-real-test'\n",
+            "API_KEY='phm_bbbb'\n",
+        );
     }
 
     #[test]
     fn rewrite_preserves_export_prefix() {
-        let content = "export API_KEY=sk-real-test\n";
-        let dotenv = DotenvFile::parse_str(content);
-        let tm = token_map_for("API_KEY", "phm_cccc");
-        let (out, _) = dotenv.rewrite_with_phantoms(&tm);
-        assert_eq!(out, "export API_KEY=phm_cccc\n");
+        assert_rewrite(
+            "API_KEY",
+            "phm_cccc",
+            "export API_KEY=sk-real-test\n",
+            "export API_KEY=phm_cccc\n",
+        );
     }
 
     #[test]
     fn rewrite_preserves_leading_indentation() {
-        let content = "  API_KEY=sk-real-test\n";
-        let dotenv = DotenvFile::parse_str(content);
-        let tm = token_map_for("API_KEY", "phm_dddd");
-        let (out, _) = dotenv.rewrite_with_phantoms(&tm);
-        assert_eq!(out, "  API_KEY=phm_dddd\n");
+        assert_rewrite(
+            "API_KEY",
+            "phm_dddd",
+            "  API_KEY=sk-real-test\n",
+            "  API_KEY=phm_dddd\n",
+        );
     }
 
     #[test]
@@ -1060,21 +1089,60 @@ KEY3=unquoted
     fn rewrite_falls_back_for_multiline_quoted_value() {
         // Multi-line PEM-style values aren't format-preserved; the splice
         // path is skipped and the canonical KEY=value reformat is emitted.
-        let content = "PRIVATE_KEY=\"line1\nline2\"\n";
-        let dotenv = DotenvFile::parse_str(content);
-        let tm = token_map_for("PRIVATE_KEY", "phm_eeee");
-        let (out, _) = dotenv.rewrite_with_phantoms(&tm);
-        assert!(out.contains("PRIVATE_KEY=phm_eeee"));
+        // Asserting an exact match (not just `contains`) verifies the
+        // surrounding quotes have been dropped by the canonical reformat.
+        assert_rewrite(
+            "PRIVATE_KEY",
+            "phm_eeee",
+            "PRIVATE_KEY=\"line1\nline2\"\n",
+            "PRIVATE_KEY=phm_eeee\n",
+        );
     }
 
     #[test]
     fn rewrite_falls_back_for_double_quoted_value_with_escapes() {
         // \n inside double quotes means the parsed value differs from the
         // raw bytes; splicing back would lose the escape, so reformat.
-        let content = "MULTILINE_KEY=\"a\\nb\"\n";
+        assert_rewrite(
+            "MULTILINE_KEY",
+            "phm_ffff",
+            "MULTILINE_KEY=\"a\\nb\"\n",
+            "MULTILINE_KEY=phm_ffff\n",
+        );
+    }
+
+    #[test]
+    fn parse_strips_inline_comment_from_unquoted_value() {
+        // Standard .env convention: `#` preceded by whitespace starts an
+        // inline comment. Without this, the comment would be stored as part
+        // of the secret value and injected into outbound API requests.
+        let content = "API_KEY=sk-real-test  # production key\n";
         let dotenv = DotenvFile::parse_str(content);
-        let tm = token_map_for("MULTILINE_KEY", "phm_ffff");
-        let (out, _) = dotenv.rewrite_with_phantoms(&tm);
-        assert!(out.contains("MULTILINE_KEY=phm_ffff"));
+        let entries = dotenv.entries();
+        assert_eq!(entries[0].key, "API_KEY");
+        assert_eq!(entries[0].value, "sk-real-test");
+    }
+
+    #[test]
+    fn parse_keeps_hash_inside_unquoted_value_when_no_preceding_whitespace() {
+        // `#` not preceded by whitespace is part of the value (e.g. URL
+        // fragments, query strings, base64 padding-adjacent sequences).
+        let content = "URL=https://example.com/path#section\n";
+        let dotenv = DotenvFile::parse_str(content);
+        let entries = dotenv.entries();
+        assert_eq!(entries[0].value, "https://example.com/path#section");
+    }
+
+    #[test]
+    fn rewrite_preserves_inline_comment_after_phantom_token() {
+        // The comment is part of the original line bytes after the value
+        // span, so format preservation should splice the new value in
+        // front of it without disturbing the comment.
+        assert_rewrite(
+            "API_KEY",
+            "phm_gggg",
+            "API_KEY=sk-real-test  # production key\n",
+            "API_KEY=phm_gggg  # production key\n",
+        );
     }
 }

--- a/crates/phantom-core/src/dotenv.rs
+++ b/crates/phantom-core/src/dotenv.rs
@@ -32,10 +32,35 @@ pub struct DotenvFile {
 
 #[derive(Debug, Clone)]
 enum DotenvLine {
-    /// A key=value pair.
-    Entry(EnvEntry),
+    /// A key=value pair. The optional `RawLineFormat` carries enough source
+    /// info to splice a new value into the original line, preserving quotes,
+    /// indentation, the `export ` prefix, and trailing inline comments.
+    /// Multi-line quoted values and entries with embedded escape sequences
+    /// store `None` and fall through to the canonical `KEY=value` reformat.
+    Entry(EnvEntry, Option<RawLineFormat>),
     /// A comment or blank line, stored verbatim.
     Other(String),
+}
+
+/// Captures the byte span occupied by an entry's value within the original
+/// source line, so phantom-token substitution can preserve everything around
+/// it. Only populated for single-line entries that can be safely round-tripped
+/// via value-only splicing.
+#[derive(Debug, Clone)]
+struct RawLineFormat {
+    raw: String,
+    value_start: usize,
+    value_end: usize,
+}
+
+impl RawLineFormat {
+    fn with_value(&self, new_value: &str) -> String {
+        let mut out = String::with_capacity(self.raw.len() + new_value.len());
+        out.push_str(&self.raw[..self.value_start]);
+        out.push_str(new_value);
+        out.push_str(&self.raw[self.value_end..]);
+        out
+    }
 }
 
 impl DotenvFile {
@@ -91,10 +116,35 @@ impl DotenvFile {
 
             let raw_value = working[eq_pos + 1..].trim_start();
 
-            let value = if let Some(after_quote) = raw_value.strip_prefix('"') {
+            // Track byte offsets in the original `line` so we can splice a
+            // replacement value while preserving the surrounding format.
+            // Computed unconditionally; consumed only if parsing stays on a
+            // single line and produces no embedded escapes.
+            let working_offset = line.find(working).unwrap_or(0);
+            let eq_in_line = working_offset + eq_pos;
+            let raw_value_offset = eq_in_line + 1 + (working[eq_pos + 1..].len() - raw_value.len());
+
+            let (value, fmt) = if let Some(after_quote) = raw_value.strip_prefix('"') {
                 // Double-quoted — may span multiple lines (F12).
                 match find_unescaped_quote(after_quote, '"') {
-                    Some(end) => unescape_double_quoted(&after_quote[..end]),
+                    Some(end) => {
+                        let raw_inner = &after_quote[..end];
+                        let unescaped = unescape_double_quoted(raw_inner);
+                        // Format-preservable only when no escape sequence
+                        // changed the bytes; otherwise round-tripping the
+                        // unescaped value back into the source would alter it.
+                        let fmt = if unescaped == raw_inner {
+                            let value_start = raw_value_offset + 1; // skip opening "
+                            Some(RawLineFormat {
+                                raw: line.to_string(),
+                                value_start,
+                                value_end: value_start + raw_inner.len(),
+                            })
+                        } else {
+                            None
+                        };
+                        (unescaped, fmt)
+                    }
                     None => {
                         // Closing quote not on the opening line — consume
                         // subsequent lines until we find it.
@@ -117,27 +167,44 @@ impl DotenvFile {
                             out.push(DotenvLine::Other(line.to_string()));
                             continue;
                         }
-                        unescape_double_quoted(&buf)
+                        // Multi-line: format preservation not attempted.
+                        (unescape_double_quoted(&buf), None)
                     }
                 }
             } else if let Some(after_quote) = raw_value.strip_prefix('\'') {
                 // Single-quoted: literal, single-line.
                 match after_quote.find('\'') {
-                    Some(end) => after_quote[..end].to_string(),
+                    Some(end) => {
+                        let value_start = raw_value_offset + 1; // skip opening '
+                        let fmt = Some(RawLineFormat {
+                            raw: line.to_string(),
+                            value_start,
+                            value_end: value_start + end,
+                        });
+                        (after_quote[..end].to_string(), fmt)
+                    }
                     None => {
                         out.push(DotenvLine::Other(line.to_string()));
                         continue;
                     }
                 }
             } else {
-                raw_value.to_string()
+                let fmt = Some(RawLineFormat {
+                    raw: line.to_string(),
+                    value_start: raw_value_offset,
+                    value_end: raw_value_offset + raw_value.len(),
+                });
+                (raw_value.to_string(), fmt)
             };
 
-            out.push(DotenvLine::Entry(EnvEntry {
-                is_phantom: PhantomToken::is_phantom_token(&value),
-                key,
-                value,
-            }));
+            out.push(DotenvLine::Entry(
+                EnvEntry {
+                    is_phantom: PhantomToken::is_phantom_token(&value),
+                    key,
+                    value,
+                },
+                fmt,
+            ));
         }
 
         Self { lines: out }
@@ -148,7 +215,7 @@ impl DotenvFile {
         self.lines
             .iter()
             .filter_map(|line| match line {
-                DotenvLine::Entry(entry) => Some(entry),
+                DotenvLine::Entry(entry, _) => Some(entry),
                 _ => None,
             })
             .collect()
@@ -198,7 +265,7 @@ impl DotenvFile {
 
         for line in &self.lines {
             match line {
-                DotenvLine::Entry(entry) => {
+                DotenvLine::Entry(entry, _) => {
                     if entry.is_phantom || classify(entry) == SecretClassification::Secret {
                         // Secret → placeholder
                         let placeholder = generate_placeholder(&entry.key, config);
@@ -232,16 +299,25 @@ impl DotenvFile {
 
         for line in &self.lines {
             match line {
-                DotenvLine::Entry(entry) => {
+                DotenvLine::Entry(entry, fmt) => {
                     if let Some(token) = token_map.get_token(&entry.key) {
                         // Replace value with phantom token (works for both initial and rotation)
                         if !entry.is_phantom {
                             original_values.insert(entry.key.clone(), entry.value.clone());
                         }
-                        output_lines.push(format!("{}={}", entry.key, token));
+                        let rendered = match fmt {
+                            Some(f) => f.with_value(token.as_str()),
+                            None => format!("{}={}", entry.key, token),
+                        };
+                        output_lines.push(rendered);
                     } else {
-                        // No mapping for this key, keep as-is (non-secret env vars)
-                        output_lines.push(format!("{}={}", entry.key, entry.value));
+                        // No mapping for this key, keep as-is (non-secret env vars).
+                        // Preserve the original line verbatim when format info exists.
+                        let rendered = match fmt {
+                            Some(f) => f.raw.clone(),
+                            None => format!("{}={}", entry.key, entry.value),
+                        };
+                        output_lines.push(rendered);
                     }
                 }
                 DotenvLine::Other(text) => {
@@ -919,5 +995,86 @@ KEY3=unquoted
         let (rewritten, _) = dotenv.rewrite_with_phantoms(&token_map);
         assert!(rewritten.contains("# This is a comment"));
         assert!(rewritten.contains("# Another comment"));
+    }
+
+    /// Format preservation: when a value gets a phantom token, the surrounding
+    /// quotes/whitespace/`export` prefix on the same line should survive.
+    /// Verifies the splice path rather than the canonical reformat path.
+    fn token_map_for(key: &str, token: &str) -> TokenMap {
+        let mut tm = TokenMap::new();
+        tm.insert_with_token(
+            key.to_string(),
+            PhantomToken::parse(token).expect("test token must start with phm_"),
+        );
+        tm
+    }
+
+    #[test]
+    fn rewrite_preserves_double_quotes() {
+        let content = "API_KEY=\"sk-real-test\"\n";
+        let dotenv = DotenvFile::parse_str(content);
+        let tm = token_map_for("API_KEY", "phm_aaaa");
+        let (out, _) = dotenv.rewrite_with_phantoms(&tm);
+        assert_eq!(out, "API_KEY=\"phm_aaaa\"\n");
+    }
+
+    #[test]
+    fn rewrite_preserves_single_quotes() {
+        let content = "API_KEY='sk-real-test'\n";
+        let dotenv = DotenvFile::parse_str(content);
+        let tm = token_map_for("API_KEY", "phm_bbbb");
+        let (out, _) = dotenv.rewrite_with_phantoms(&tm);
+        assert_eq!(out, "API_KEY='phm_bbbb'\n");
+    }
+
+    #[test]
+    fn rewrite_preserves_export_prefix() {
+        let content = "export API_KEY=sk-real-test\n";
+        let dotenv = DotenvFile::parse_str(content);
+        let tm = token_map_for("API_KEY", "phm_cccc");
+        let (out, _) = dotenv.rewrite_with_phantoms(&tm);
+        assert_eq!(out, "export API_KEY=phm_cccc\n");
+    }
+
+    #[test]
+    fn rewrite_preserves_leading_indentation() {
+        let content = "  API_KEY=sk-real-test\n";
+        let dotenv = DotenvFile::parse_str(content);
+        let tm = token_map_for("API_KEY", "phm_dddd");
+        let (out, _) = dotenv.rewrite_with_phantoms(&tm);
+        assert_eq!(out, "  API_KEY=phm_dddd\n");
+    }
+
+    #[test]
+    fn rewrite_preserves_non_secret_lines_verbatim() {
+        // Lines without a token mapping should round-trip exactly,
+        // including quotes and indentation.
+        let content = "  NODE_ENV=\"production\"\nexport PORT='8080'\n";
+        let dotenv = DotenvFile::parse_str(content);
+        let tm = TokenMap::new();
+        let (out, _) = dotenv.rewrite_with_phantoms(&tm);
+        assert_eq!(out, content);
+    }
+
+    #[test]
+    fn rewrite_falls_back_for_multiline_quoted_value() {
+        // Multi-line PEM-style values aren't format-preserved; the splice
+        // path is skipped and the canonical KEY=value reformat is emitted.
+        let content = "PRIVATE_KEY=\"line1\nline2\"\n";
+        let dotenv = DotenvFile::parse_str(content);
+        let tm = token_map_for("PRIVATE_KEY", "phm_eeee");
+        let (out, _) = dotenv.rewrite_with_phantoms(&tm);
+        assert!(out.contains("PRIVATE_KEY=phm_eeee"));
+    }
+
+    #[test]
+    fn rewrite_falls_back_for_double_quoted_value_with_escapes() {
+        // \n inside double quotes means the parsed value differs from the
+        // raw bytes; splicing back would lose the escape, so reformat.
+        let content = "MULTILINE_KEY=\"a\\nb\"\n";
+        let dotenv = DotenvFile::parse_str(content);
+        let tm = token_map_for("MULTILINE_KEY", "phm_ffff");
+        let (out, _) = dotenv.rewrite_with_phantoms(&tm);
+        assert!(out.contains("MULTILINE_KEY=phm_ffff"));
     }
 }


### PR DESCRIPTION
## Summary

Format-preserving `.env` rewrite — the deferred follow-up from #49.

When a value gets a phantom-token replacement (or stays as-is), the surrounding line formatting on the same line is preserved instead of being canonicalized to `KEY=value`:

- Single and double quotes
- The `export ` prefix
- Leading indentation
- Trailing inline comments (`KEY=val  # comment` → `KEY=phm_xxx  # comment`)

Multi-line quoted values (PEM-style) and double-quoted values with escape sequences fall through to the existing canonical reformat path — preserving formatting safely is impossible for those cases without a much more invasive parser change.

## Bonus fix: inline comments no longer leak into outbound API requests

While building this, the second-pass review caught a pre-existing parser bug: `API_KEY=sk-real # production` was storing `sk-real # production` as the secret value, which the proxy then injected verbatim into outbound API headers — breaking auth and leaking the comment text.

The new parser strips inline comments from unquoted values per standard `.env` convention (`#` preceded by whitespace), and the format-preservation splice then puts the new phantom token in front of (rather than overwriting) the original comment.

## Implementation

- New private `RawLineFormat { raw, value_start, value_end }` records the byte span of the value within the original source line.
- `DotenvLine::Entry` now carries `Option<RawLineFormat>`. Set for single-line entries that round-trip safely; `None` for multi-line and escape-bearing cases.
- `rewrite_with_phantoms` splices into `raw` when format info exists; falls through to `format!("{key}={value}")` otherwise. Non-token-mapped entries also round-trip verbatim.
- `entries()`, `real_secret_entries()`, `classified_entries()`, `public_key_entries()`, and `generate_example_content` updated to destructure the new variant; their public behavior is unchanged.

## Test plan

- [x] `cargo test -p phantom-secrets-core dotenv` — 29 tests pass (19 existing + 10 new)
- [x] `cargo test` (workspace) — 165 tests pass, 3 ignored (cloud, require auth)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Format-preservation paths covered: double quotes, single quotes, `export` prefix, leading indentation, non-secret round-trip, inline comment after token
- [x] Fallback paths covered: multi-line quoted values, double-quoted values with escapes
- [x] Inline-comment correctness covered: comment stripped from stored value, `#` without preceding whitespace stays in value (URL fragments)
- [ ] CI green on Linux/macOS/Windows

## Polish loop summary

- Iteration 1: code-reviewer flagged the inline-comment leak (CRITICAL); simplifier replaced a brittle `line.find()` with deterministic offset arithmetic and consolidated the test helper.
- Iteration 2: re-review confirmed the comment-strip fix is correct (UTF-8-safe, offsets deterministic, test assertion matches mechanical output). No further issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)