### PR TITLE
feat: UX polish + multi-project init + cheap security wins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1815,6 +1815,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "which",

--- a/crates/phantom-cli/Cargo.toml
+++ b/crates/phantom-cli/Cargo.toml
@@ -38,6 +38,7 @@ base64 = { workspace = true }
 notify = "7"
 rpassword = "7"
 self_update = { version = "0.42", default-features = false, features = ["rustls", "compression-flate2", "compression-zip-deflate", "archive-tar", "archive-zip"] }
+toml = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/phantom-cli/src/commands/env.rs
+++ b/crates/phantom-cli/src/commands/env.rs
@@ -12,7 +12,10 @@ pub fn run(output: &str) -> Result<()> {
     let output_path = project_dir.join(output);
 
     if !env_path.exists() {
-        anyhow::bail!("No .env file found in current directory.");
+        anyhow::bail!(
+            "No .env file found in current directory.\n  {}",
+            crate::util::docs_url("getting-started")
+        );
     }
 
     let dotenv = DotenvFile::parse_file(&env_path).context("Failed to read .env")?;

--- a/crates/phantom-cli/src/commands/init/mod.rs
+++ b/crates/phantom-cli/src/commands/init/mod.rs
@@ -2,6 +2,7 @@ mod config;
 mod docs;
 mod env;
 mod hooks;
+pub mod multi;
 mod prompts;
 mod vault;
 
@@ -198,6 +199,14 @@ fn print_next_steps(config_path: &Path) {
     }
 
     item("Open your dashboard:", "phantom open");
+    item(
+        "Block raw-secret commits (recommended for teams):",
+        "pre-commit install   # uses .pre-commit-hooks.yaml shipped with phantom",
+    );
+    item(
+        "Other AI tools (Cursor, Windsurf, Codex):",
+        "phantom setup --client cursor|windsurf|codex|claude   # --print to stdout",
+    );
 
     println!();
 }

--- a/crates/phantom-cli/src/commands/init/multi.rs
+++ b/crates/phantom-cli/src/commands/init/multi.rs
@@ -1,0 +1,281 @@
+use anyhow::{Context, Result};
+use colored::Colorize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Filenames we treat as "this repo has a .env worth protecting."
+const ENV_FILENAMES: &[&str] = &[
+    ".env",
+    ".env.local",
+    ".env.development",
+    ".env.development.local",
+    ".env.production",
+    ".env.production.local",
+    ".env.staging",
+];
+
+const SKIP_DIRS: &[&str] = &[
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".nuxt",
+    ".venv",
+    "venv",
+    "__pycache__",
+];
+
+const DEFAULT_DEPTH: usize = 5;
+
+pub fn run(root: PathBuf, dry_run: bool) -> Result<()> {
+    let root = root
+        .canonicalize()
+        .with_context(|| format!("Could not resolve {}", root.display()))?;
+
+    println!(
+        "{} Scanning {} for repos with .env files...",
+        "->".blue().bold(),
+        root.display()
+    );
+
+    let candidates = find_candidates(&root, DEFAULT_DEPTH);
+
+    if candidates.is_empty() {
+        println!("{} No candidate repos found.", "!".yellow().bold());
+        return Ok(());
+    }
+
+    println!(
+        "{} Found {} repo(s):\n",
+        "->".blue().bold(),
+        candidates.len()
+    );
+
+    let mut protected = 0usize;
+    let mut skipped = 0usize;
+    let mut errored = 0usize;
+
+    for repo in &candidates {
+        let rel = repo.strip_prefix(&root).unwrap_or(repo);
+        let display = if rel.as_os_str().is_empty() {
+            "(this repo)".to_string()
+        } else {
+            rel.display().to_string()
+        };
+
+        if repo.join(".phantom.toml").exists() {
+            println!("  {} {} (already protected)", "·".dimmed(), display);
+            skipped += 1;
+            continue;
+        }
+        if dry_run {
+            println!("  {} {} (would protect)", "+".cyan().bold(), display);
+            continue;
+        }
+        match run_init_for(repo) {
+            Ok(count) => {
+                println!(
+                    "  {} {} ({} secret{} protected)",
+                    "ok".green().bold(),
+                    display,
+                    count,
+                    if count == 1 { "" } else { "s" }
+                );
+                protected += 1;
+            }
+            Err(e) => {
+                println!("  {} {}: {}", "FAIL".red().bold(), display, e);
+                errored += 1;
+            }
+        }
+    }
+
+    let summary = if dry_run {
+        format!(
+            "{} repo(s) would be protected · {} already protected",
+            candidates.len() - skipped,
+            skipped
+        )
+    } else {
+        format!("protected: {protected} · skipped: {skipped} · errors: {errored}")
+    };
+    println!("\n{} {}", "done".green().bold(), summary);
+
+    if errored > 0 {
+        anyhow::bail!("{errored} repo(s) failed to init — see output above");
+    }
+    Ok(())
+}
+
+/// Walk `root` up to `max_depth` levels. Yield directories that contain both
+/// `.git/` AND at least one of `ENV_FILENAMES`. Stop descending once a match
+/// is found (don't recurse into a protected repo's subdirs).
+fn find_candidates(root: &Path, max_depth: usize) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    walk(root, max_depth, &mut out);
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn walk(dir: &Path, depth_remaining: usize, out: &mut Vec<PathBuf>) {
+    if depth_remaining == 0 {
+        return;
+    }
+
+    let has_git = dir.join(".git").exists();
+    let has_env = ENV_FILENAMES.iter().any(|n| dir.join(n).exists());
+
+    if has_git && has_env {
+        out.push(dir.to_path_buf());
+        return; // Don't descend into an already-discovered repo.
+    }
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        // Skip dot-dirs entirely (.git, .cache, .vscode, etc.)
+        if name_str.starts_with('.') {
+            continue;
+        }
+        // Skip well-known noise dirs.
+        if SKIP_DIRS.iter().any(|s| **s == *name_str) {
+            continue;
+        }
+
+        if let Ok(ft) = entry.file_type() {
+            if ft.is_dir() {
+                walk(&path, depth_remaining - 1, out);
+            }
+        }
+    }
+}
+
+/// Spawn a child `phantom init` in `repo`. Captures output and returns the
+/// number of secrets protected (parsed from stdout) on success.
+fn run_init_for(repo: &Path) -> Result<usize> {
+    let exe = std::env::current_exe().context("Could not resolve current exe")?;
+    let output = Command::new(&exe)
+        .arg("init")
+        .current_dir(repo)
+        .output()
+        .context("Failed to spawn `phantom init`")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let combined = if stderr.trim().is_empty() {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        } else {
+            stderr.trim().to_string()
+        };
+        anyhow::bail!("{}", first_line(&combined));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_secret_count(&stdout))
+}
+
+fn first_line(s: &str) -> String {
+    s.lines().next().unwrap_or(s).to_string()
+}
+
+/// Parse "Found N secret(s) to protect:" from `phantom init` stdout.
+/// Returns 0 if not found (still treated as success).
+fn parse_secret_count(stdout: &str) -> usize {
+    for line in stdout.lines() {
+        if let Some(rest) = line.split_once("Found ").map(|(_, r)| r) {
+            if let Some((num, _)) = rest.split_once(' ') {
+                if let Ok(n) = num.parse::<usize>() {
+                    return n;
+                }
+            }
+        }
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn touch(path: &Path) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, "").unwrap();
+    }
+
+    #[test]
+    fn find_candidates_picks_up_repos_with_env_and_git() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+
+        // repo-a: has .git + .env  → should match
+        touch(&root.join("repo-a/.git/HEAD"));
+        touch(&root.join("repo-a/.env"));
+
+        // repo-b: has .git + .env.local → should match
+        touch(&root.join("repo-b/.git/HEAD"));
+        touch(&root.join("repo-b/.env.local"));
+
+        // repo-c: has .env but no .git → should NOT match
+        touch(&root.join("repo-c/.env"));
+
+        // repo-d: has .git but no .env → should NOT match
+        touch(&root.join("repo-d/.git/HEAD"));
+
+        let found = find_candidates(root, 5);
+        assert_eq!(found.len(), 2);
+        assert!(found.iter().any(|p| p.ends_with("repo-a")));
+        assert!(found.iter().any(|p| p.ends_with("repo-b")));
+    }
+
+    #[test]
+    fn find_candidates_skips_node_modules() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+
+        touch(&root.join("node_modules/some-pkg/.git/HEAD"));
+        touch(&root.join("node_modules/some-pkg/.env"));
+
+        let found = find_candidates(root, 5);
+        assert_eq!(found.len(), 0);
+    }
+
+    #[test]
+    fn find_candidates_does_not_descend_into_found_repo() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+
+        // outer repo
+        touch(&root.join("repo/.git/HEAD"));
+        touch(&root.join("repo/.env"));
+        // inner "repo" should be ignored
+        touch(&root.join("repo/inner/.git/HEAD"));
+        touch(&root.join("repo/inner/.env"));
+
+        let found = find_candidates(root, 5);
+        assert_eq!(found.len(), 1);
+        assert!(found[0].ends_with("repo"));
+    }
+
+    #[test]
+    fn parse_secret_count_extracts_n() {
+        let stdout = "-> Reading .env...\n-> Found 5 secret(s) to protect:\n   + OPENAI_API_KEY\n";
+        assert_eq!(parse_secret_count(stdout), 5);
+    }
+
+    #[test]
+    fn parse_secret_count_returns_zero_when_absent() {
+        assert_eq!(parse_secret_count("hello world"), 0);
+    }
+}

--- a/crates/phantom-cli/src/commands/login.rs
+++ b/crates/phantom-cli/src/commands/login.rs
@@ -117,5 +117,8 @@ pub fn run() -> Result<()> {
     }
 
     spinner.finish_and_clear();
-    anyhow::bail!("Login timed out. Run `phantom login` to try again.")
+    anyhow::bail!(
+        "Login timed out. Run `phantom login` to try again.\n  {}",
+        crate::util::docs_url("login")
+    )
 }

--- a/crates/phantom-cli/src/commands/setup.rs
+++ b/crates/phantom-cli/src/commands/setup.rs
@@ -1,26 +1,104 @@
 use anyhow::{Context, Result};
+use clap::ValueEnum;
 use colored::Colorize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-/// Set up Phantom auto-mode for Claude Code.
-/// Configures MCP server and hooks in .claude/settings.local.json.
-pub fn run() -> Result<()> {
+/// AI client whose MCP config we know how to write.
+#[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq)]
+pub enum Client {
+    /// Claude Code — writes .claude/settings.local.json in the project
+    #[value(name = "claude", alias = "claude-code")]
+    ClaudeCode,
+    /// Cursor — writes ~/.cursor/mcp.json
+    Cursor,
+    /// Windsurf — writes ~/.codeium/windsurf/mcp_config.json
+    Windsurf,
+    /// Codex (OpenAI) — patches ~/.codex/config.toml
+    Codex,
+}
+
+impl Client {
+    fn label(self) -> &'static str {
+        match self {
+            Client::ClaudeCode => "Claude Code",
+            Client::Cursor => "Cursor",
+            Client::Windsurf => "Windsurf",
+            Client::Codex => "Codex",
+        }
+    }
+}
+
+/// The command spec we write into each client's MCP config.
+struct McpCommand {
+    command: String,
+    args: Vec<String>,
+}
+
+impl McpCommand {
+    fn args_json(&self) -> serde_json::Value {
+        serde_json::Value::Array(
+            self.args
+                .iter()
+                .map(|a| serde_json::Value::String(a.clone()))
+                .collect(),
+        )
+    }
+}
+
+pub fn run(client: Option<Client>, print: bool) -> Result<()> {
+    let client = client.unwrap_or(Client::ClaudeCode);
+    let mcp = mcp_command_spec();
+
+    if print {
+        return print_snippet(client, &mcp);
+    }
+
+    println!(
+        "{} Setting up Phantom for {}...",
+        "->".blue().bold(),
+        client.label().bold()
+    );
+    if mcp.command == "npx" {
+        println!(
+            "   {} phantom-mcp not on PATH — using `npx -y phantom-secrets-mcp` as fallback.",
+            "note".dimmed()
+        );
+    }
+
+    match client {
+        Client::ClaudeCode => setup_claude_code(&mcp),
+        Client::Cursor => setup_cursor(&mcp),
+        Client::Windsurf => setup_windsurf(&mcp),
+        Client::Codex => setup_codex(&mcp),
+    }
+}
+
+/// Resolve the command + args we want each MCP client to invoke. Prefers a
+/// real `phantom-mcp` binary on disk; falls back to `npx -y phantom-secrets-mcp`
+/// when nothing is found, so the config still works on a fresh machine.
+fn mcp_command_spec() -> McpCommand {
+    if let Some(path) = find_mcp_binary() {
+        McpCommand {
+            command: path,
+            args: vec![],
+        }
+    } else {
+        McpCommand {
+            command: "npx".to_string(),
+            args: vec!["-y".to_string(), "phantom-secrets-mcp".to_string()],
+        }
+    }
+}
+
+// ───────────────────────── Claude Code ─────────────────────────
+
+fn setup_claude_code(mcp: &McpCommand) -> Result<()> {
     let project_dir = std::env::current_dir()?;
     let claude_dir = project_dir.join(".claude");
     let settings_path = claude_dir.join("settings.local.json");
 
-    // Find phantom-mcp binary
-    let mcp_binary = find_mcp_binary();
-
-    println!(
-        "{} Setting up Phantom auto-mode for Claude Code...",
-        "->".blue().bold()
-    );
-
-    // Create .claude directory if needed
     std::fs::create_dir_all(&claude_dir)?;
 
-    // Load existing settings or create new
     let mut settings: serde_json::Value = if settings_path.exists() {
         let content = std::fs::read_to_string(&settings_path)?;
         serde_json::from_str(&content).context("Failed to parse .claude/settings.local.json")?
@@ -28,44 +106,34 @@ pub fn run() -> Result<()> {
         serde_json::json!({})
     };
 
-    // Ensure settings is an object
     let obj = settings
         .as_object_mut()
         .ok_or_else(|| anyhow::anyhow!("settings.local.json is not a JSON object"))?;
 
-    // Add MCP server configuration
-    if let Some(mcp_path) = &mcp_binary {
-        let mcp_servers = obj
-            .entry("mcpServers")
-            .or_insert_with(|| serde_json::json!({}));
+    let mcp_servers = obj
+        .entry("mcpServers")
+        .or_insert_with(|| serde_json::json!({}));
 
-        if let Some(servers) = mcp_servers.as_object_mut() {
-            if !servers.contains_key("phantom") {
-                servers.insert(
-                    "phantom".to_string(),
-                    serde_json::json!({
-                        "command": mcp_path,
-                        "args": []
-                    }),
-                );
-                println!(
-                    "   {} MCP server: {} -> {}",
-                    "+".green().bold(),
-                    "phantom".bold(),
-                    mcp_path.dimmed()
-                );
-            } else {
-                println!("   {} MCP server already configured", "-".dimmed());
-            }
+    if let Some(servers) = mcp_servers.as_object_mut() {
+        if !servers.contains_key("phantom") {
+            servers.insert(
+                "phantom".to_string(),
+                serde_json::json!({
+                    "command": mcp.command,
+                    "args": mcp.args_json(),
+                }),
+            );
+            println!(
+                "   {} MCP server: {} -> {}",
+                "+".green().bold(),
+                "phantom".bold(),
+                mcp.command.dimmed()
+            );
+        } else {
+            println!("   {} MCP server already configured", "-".dimmed());
         }
-    } else {
-        println!(
-            "   {} phantom-mcp binary not found — install it and re-run",
-            "warn".yellow()
-        );
     }
 
-    // Add permissions to allow Claude Code to read .env files
     // After phantom init, .env only contains worthless phantom tokens — safe for AI to read
     let permissions = obj
         .entry("permissions")
@@ -99,7 +167,6 @@ pub fn run() -> Result<()> {
             }
         }
 
-        // Check if .env is in deny rules and warn
         if let Some(deny) = perms.get("deny") {
             if let Some(deny_arr) = deny.as_array() {
                 let has_env_deny = deny_arr
@@ -119,44 +186,248 @@ pub fn run() -> Result<()> {
         }
     }
 
-    // Write settings
     let content =
         serde_json::to_string_pretty(&settings).context("Failed to serialize settings")?;
     std::fs::write(&settings_path, content)?;
 
     println!("\n{} Claude Code configured!", "ok".green().bold());
-
-    if mcp_binary.is_some() {
-        println!(
-            "{} Phantom MCP tools are now available in Claude Code.",
-            "->".blue().bold()
-        );
-    }
-
     println!(
-        "{} .env files are allowed — they only contain phantom tokens after init.",
-        "->".blue().bold()
-    );
-
-    println!(
-        "\n{} Restart Claude Code to activate.",
-        "next".blue().bold()
+        "{} Phantom MCP tools are now available. {} to activate.",
+        "->".blue().bold(),
+        "Restart Claude Code".bold()
     );
 
     Ok(())
 }
 
+// ─────────────────────────── Cursor ────────────────────────────
+
+fn setup_cursor(mcp: &McpCommand) -> Result<()> {
+    let path = home_path(".cursor/mcp.json")?;
+    upsert_mcp_servers_json(&path, mcp)?;
+    println!(
+        "\n{} Cursor configured at {}",
+        "ok".green().bold(),
+        display(&path).dimmed()
+    );
+    println!(
+        "{} {} to activate.",
+        "->".blue().bold(),
+        "Restart Cursor".bold()
+    );
+    Ok(())
+}
+
+// ─────────────────────────── Windsurf ──────────────────────────
+
+fn setup_windsurf(mcp: &McpCommand) -> Result<()> {
+    let path = home_path(".codeium/windsurf/mcp_config.json")?;
+    upsert_mcp_servers_json(&path, mcp)?;
+    println!(
+        "\n{} Windsurf configured at {}",
+        "ok".green().bold(),
+        display(&path).dimmed()
+    );
+    println!(
+        "{} {} to activate.",
+        "->".blue().bold(),
+        "Restart Windsurf".bold()
+    );
+    Ok(())
+}
+
+// ──────────────────────────── Codex ────────────────────────────
+
+fn setup_codex(mcp: &McpCommand) -> Result<()> {
+    let path = home_path(".codex/config.toml")?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let mut doc: toml::Table = if path.exists() {
+        let content = std::fs::read_to_string(&path)?;
+        toml::from_str(&content).context("Failed to parse ~/.codex/config.toml")?
+    } else {
+        toml::Table::new()
+    };
+
+    // Get-or-create [mcp_servers]
+    let mcp_servers = doc
+        .entry("mcp_servers".to_string())
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+    let servers = mcp_servers
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!("[mcp_servers] is not a table in ~/.codex/config.toml"))?;
+
+    let already = servers.contains_key("phantom");
+    let mut entry = toml::Table::new();
+    entry.insert(
+        "command".to_string(),
+        toml::Value::String(mcp.command.clone()),
+    );
+    entry.insert(
+        "args".to_string(),
+        toml::Value::Array(
+            mcp.args
+                .iter()
+                .map(|a| toml::Value::String(a.clone()))
+                .collect(),
+        ),
+    );
+    servers.insert("phantom".to_string(), toml::Value::Table(entry));
+
+    let serialized = toml::to_string_pretty(&doc).context("Failed to serialize codex config")?;
+    std::fs::write(&path, serialized)?;
+
+    if already {
+        println!(
+            "   {} MCP server already configured -> {}",
+            "-".dimmed(),
+            mcp.command.dimmed()
+        );
+    } else {
+        println!(
+            "   {} MCP server: {} -> {}",
+            "+".green().bold(),
+            "phantom".bold(),
+            mcp.command.dimmed()
+        );
+    }
+    println!(
+        "\n{} Codex configured at {}",
+        "ok".green().bold(),
+        display(&path).dimmed()
+    );
+    println!(
+        "{} {} to activate.",
+        "->".blue().bold(),
+        "Restart Codex".bold()
+    );
+
+    Ok(())
+}
+
+// ─────────────────────── Shared JSON writer ────────────────────
+
+/// Read-or-create a JSON file with `mcpServers.phantom = {command, args}`.
+/// Used by Cursor and Windsurf, which share the same MCP config schema.
+fn upsert_mcp_servers_json(path: &Path, mcp: &McpCommand) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let mut value: serde_json::Value = if path.exists() {
+        let content = std::fs::read_to_string(path)?;
+        if content.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {}", path.display()))?
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    let obj = value
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("{} is not a JSON object", path.display()))?;
+
+    let servers = obj
+        .entry("mcpServers")
+        .or_insert_with(|| serde_json::json!({}));
+    let servers_obj = servers
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("mcpServers is not an object in {}", path.display()))?;
+
+    let already = servers_obj.contains_key("phantom");
+    servers_obj.insert(
+        "phantom".to_string(),
+        serde_json::json!({
+            "command": mcp.command,
+            "args": mcp.args_json(),
+        }),
+    );
+
+    let content = serde_json::to_string_pretty(&value).context("Failed to serialize MCP config")?;
+    std::fs::write(path, content)?;
+
+    println!(
+        "   {} MCP server: {} -> {}",
+        if already {
+            "-".dimmed()
+        } else {
+            "+".green().bold()
+        },
+        "phantom".bold(),
+        mcp.command.dimmed()
+    );
+
+    Ok(())
+}
+
+// ──────────────────────────── --print ──────────────────────────
+
+fn print_snippet(client: Client, mcp: &McpCommand) -> Result<()> {
+    match client {
+        Client::ClaudeCode | Client::Cursor | Client::Windsurf => {
+            let body = serde_json::json!({
+                "mcpServers": {
+                    "phantom": {
+                        "command": mcp.command,
+                        "args": mcp.args_json(),
+                    }
+                }
+            });
+            let target = match client {
+                Client::ClaudeCode => ".claude/settings.local.json (project)",
+                Client::Cursor => "~/.cursor/mcp.json",
+                Client::Windsurf => "~/.codeium/windsurf/mcp_config.json",
+                _ => unreachable!(),
+            };
+            println!("# {} — {}", client.label(), target);
+            println!("{}", serde_json::to_string_pretty(&body)?);
+        }
+        Client::Codex => {
+            let mut servers = toml::Table::new();
+            let mut entry = toml::Table::new();
+            entry.insert(
+                "command".to_string(),
+                toml::Value::String(mcp.command.clone()),
+            );
+            entry.insert(
+                "args".to_string(),
+                toml::Value::Array(
+                    mcp.args
+                        .iter()
+                        .map(|a| toml::Value::String(a.clone()))
+                        .collect(),
+                ),
+            );
+            servers.insert("phantom".to_string(), toml::Value::Table(entry));
+            let mut doc = toml::Table::new();
+            doc.insert("mcp_servers".to_string(), toml::Value::Table(servers));
+            println!("# Codex — ~/.codex/config.toml");
+            println!("{}", toml::to_string_pretty(&doc)?);
+        }
+    }
+    Ok(())
+}
+
+// ─────────────────────────── Helpers ───────────────────────────
+
 fn find_mcp_binary() -> Option<String> {
-    // Check common locations
     let candidates = [
-        // Same directory as phantom binary
         std::env::current_exe()
             .ok()
             .and_then(|p| p.parent().map(|d| d.join("phantom-mcp")))
             .map(|p| p.to_string_lossy().to_string()),
-        // Cargo install location
-        dirs_home().map(|h| format!("{h}/.cargo/bin/phantom-mcp")),
-        // PATH
+        dirs::home_dir().map(|h| {
+            h.join(".cargo")
+                .join("bin")
+                .join("phantom-mcp")
+                .to_string_lossy()
+                .into_owned()
+        }),
         Some("phantom-mcp".to_string()),
     ];
 
@@ -173,6 +444,98 @@ fn find_mcp_binary() -> Option<String> {
     None
 }
 
-fn dirs_home() -> Option<String> {
-    dirs::home_dir().map(|p| p.to_string_lossy().into_owned())
+fn home_path(rel: &str) -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not resolve home dir"))?;
+    Ok(home.join(rel))
+}
+
+fn display(path: &Path) -> String {
+    if let Some(home) = dirs::home_dir() {
+        if let Ok(suffix) = path.strip_prefix(&home) {
+            return format!("~/{}", suffix.display());
+        }
+    }
+    path.display().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use tempfile::tempdir;
+
+    fn fake_mcp() -> McpCommand {
+        McpCommand {
+            command: "/usr/local/bin/phantom-mcp".to_string(),
+            args: vec![],
+        }
+    }
+
+    #[test]
+    fn cursor_writer_creates_config_when_missing() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("mcp.json");
+        upsert_mcp_servers_json(&path, &fake_mcp()).unwrap();
+        let v: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            v["mcpServers"]["phantom"]["command"],
+            "/usr/local/bin/phantom-mcp"
+        );
+        assert_eq!(
+            v["mcpServers"]["phantom"]["args"].as_array().unwrap().len(),
+            0
+        );
+    }
+
+    #[test]
+    fn cursor_writer_preserves_other_settings() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{"mcpServers": {"other": {"command": "x"}}, "extra": 42}"#,
+        )
+        .unwrap();
+        upsert_mcp_servers_json(&path, &fake_mcp()).unwrap();
+        let v: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(v["mcpServers"]["other"]["command"], "x");
+        assert_eq!(
+            v["mcpServers"]["phantom"]["command"],
+            "/usr/local/bin/phantom-mcp"
+        );
+        assert_eq!(v["extra"], 42);
+    }
+
+    #[test]
+    fn cursor_writer_replaces_existing_phantom_entry() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{"mcpServers": {"phantom": {"command": "/old/path", "args": ["x"]}}}"#,
+        )
+        .unwrap();
+        upsert_mcp_servers_json(&path, &fake_mcp()).unwrap();
+        let v: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            v["mcpServers"]["phantom"]["command"],
+            "/usr/local/bin/phantom-mcp"
+        );
+        assert_eq!(
+            v["mcpServers"]["phantom"]["args"].as_array().unwrap().len(),
+            0
+        );
+    }
+
+    #[test]
+    fn npx_fallback_command_spec() {
+        // Hard to test mcp_command_spec() directly because it depends on env.
+        // Instead verify the args are correct when we construct the npx fallback.
+        let mcp = McpCommand {
+            command: "npx".to_string(),
+            args: vec!["-y".to_string(), "phantom-secrets-mcp".to_string()],
+        };
+        assert_eq!(mcp.args_json().as_array().unwrap().len(), 2);
+        assert_eq!(mcp.args_json()[0], "-y");
+    }
 }

--- a/crates/phantom-cli/src/commands/sync.rs
+++ b/crates/phantom-cli/src/commands/sync.rs
@@ -20,8 +20,9 @@ async fn run_async(
 
     if !config_path.exists() {
         anyhow::bail!(
-            "No .phantom.toml found. Run {} first.",
-            "phantom init".cyan().bold()
+            "No .phantom.toml found. Run {} first.\n  {}",
+            "phantom init".cyan().bold(),
+            crate::util::docs_url("sync")
         );
     }
 

--- a/crates/phantom-cli/src/commands/team.rs
+++ b/crates/phantom-cli/src/commands/team.rs
@@ -226,5 +226,34 @@ pub fn run_invite(team_id: &str, github_login: &str, role: &str) -> Result<()> {
         role
     );
 
+    println!(
+        "\n{} Send your teammate this checklist so they can join:",
+        "next".blue().bold()
+    );
+    println!(
+        "  {}. Install Phantom:    {}",
+        "1".bold(),
+        "curl -fsSL phm.dev/install | sh".cyan().bold()
+    );
+    println!(
+        "  {}. Sign in:            {}",
+        "2".bold(),
+        "phantom login".cyan().bold()
+    );
+    println!(
+        "  {}. Publish their key:  {}",
+        "3".bold(),
+        format!("phantom team key-publish {team_id}").cyan().bold()
+    );
+    println!(
+        "  {}. Pull this vault:    {}",
+        "4".bold(),
+        format!("phantom team vault-pull {team_id}").cyan().bold()
+    );
+    println!(
+        "\n{} Then re-run `phantom team vault-push {team_id}` so this teammate is sealed in.",
+        "tip".dimmed()
+    );
+
     Ok(())
 }

--- a/crates/phantom-cli/src/commands/upgrade.rs
+++ b/crates/phantom-cli/src/commands/upgrade.rs
@@ -1,7 +1,59 @@
 use colored::Colorize;
 
+/// Where each install method roots its binaries. Used to give an actionable
+/// hint when self-update isn't the right path (e.g. npm-installed phantom
+/// gets reverted on the next `npm install` if we replace the cached binary).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InstallSource {
+    Npm,
+    Homebrew,
+    Cargo,
+    Curl,
+    Unknown,
+}
+
+fn detect_install_source() -> InstallSource {
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return InstallSource::Unknown,
+    };
+    let path = exe.to_string_lossy();
+
+    // npm wrapper caches the binary under ~/.phantom-secrets/bin/phantom
+    if let Some(home) = dirs::home_dir() {
+        let npm_root = home.join(".phantom-secrets").join("bin");
+        if exe.starts_with(&npm_root) {
+            return InstallSource::Npm;
+        }
+    }
+    if path.contains("/Cellar/") || path.contains("/homebrew/") || path.contains("/linuxbrew/") {
+        return InstallSource::Homebrew;
+    }
+    if path.contains("/.cargo/bin/") {
+        return InstallSource::Cargo;
+    }
+    if path.contains("/.local/bin/") {
+        return InstallSource::Curl;
+    }
+    InstallSource::Unknown
+}
+
 pub fn run(force: bool, check_only: bool) -> anyhow::Result<()> {
     let current = env!("CARGO_PKG_VERSION");
+    let source = detect_install_source();
+
+    if matches!(source, InstallSource::Npm) {
+        println!(
+            "{} phantom was installed via npm. Use the npm package manager to upgrade:",
+            "->".blue().bold(),
+        );
+        println!("    {}", "npm i -g phantom-secrets@latest".cyan().bold());
+        println!(
+            "  {} (`phantom upgrade` would be reverted on the next `npm install`).",
+            "note".dimmed()
+        );
+        return Ok(());
+    }
 
     let update = self_update::backends::github::Update::configure()
         .repo_owner("ashlrai")
@@ -53,10 +105,15 @@ pub fn run(force: bool, check_only: bool) -> anyhow::Result<()> {
         Err(self_update::errors::Error::Io(e))
             if e.kind() == std::io::ErrorKind::PermissionDenied =>
         {
+            let cmd = match source {
+                InstallSource::Homebrew => "brew upgrade phantom",
+                InstallSource::Cargo => "cargo install phantom-secrets --force",
+                _ => "brew upgrade phantom",
+            };
             println!(
-                "{} Permission denied — if phantom was installed via Homebrew, run: {}",
+                "{} Permission denied. Try the package-manager path instead: {}",
                 "!".red().bold(),
-                "brew upgrade phantom".yellow(),
+                cmd.yellow(),
             );
             std::process::exit(1);
         }
@@ -64,4 +121,19 @@ pub fn run(force: bool, check_only: bool) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_install_source_returns_a_value() {
+        // Smoke test — the function must return without panicking. Exact
+        // value depends on where the test binary lives, so we just ensure
+        // it's stable across two calls.
+        let a = detect_install_source();
+        let b = detect_install_source();
+        assert_eq!(a, b);
+    }
 }

--- a/crates/phantom-cli/src/commands/watch.rs
+++ b/crates/phantom-cli/src/commands/watch.rs
@@ -26,7 +26,10 @@ pub fn run(auto: bool) -> Result<()> {
         .collect();
 
     if watched.is_empty() {
-        anyhow::bail!("No .env files found to watch.");
+        anyhow::bail!(
+            "No .env files found to watch.\n  {}",
+            crate::util::docs_url("getting-started")
+        );
     }
 
     println!(

--- a/crates/phantom-cli/src/commands/why.rs
+++ b/crates/phantom-cli/src/commands/why.rs
@@ -10,7 +10,10 @@ pub fn run(key: &str) -> Result<()> {
     let config_path = project_dir.join(".phantom.toml");
 
     if !env_path.exists() {
-        anyhow::bail!("No .env file found in current directory.");
+        anyhow::bail!(
+            "No .env file found in current directory.\n  {}",
+            crate::util::docs_url("getting-started")
+        );
     }
 
     let dotenv = DotenvFile::parse_file(&env_path).context("Failed to read .env")?;

--- a/crates/phantom-cli/src/main.rs
+++ b/crates/phantom-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod util;
 
 use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
@@ -9,7 +10,12 @@ use tracing_subscriber::EnvFilter;
     about = "Prevent AI coding agents from leaking your API keys",
     long_about = "Phantom replaces real secrets in your .env with worthless phantom tokens.\n\
                   A local proxy intercepts API calls, swaps in real credentials at the network layer.\n\
-                  The AI agent never sees a real secret.",
+                  The AI agent never sees a real secret.\n\n\
+                  Commands are grouped (in display order):\n  \
+                    Setup        init · setup · doctor · completion\n  \
+                    Daily use    exec · start · stop · status · check · list · add · remove · reveal · copy · env · why\n  \
+                    Sync & teams login · logout · cloud · team · sync · pull · export · import · wrap · unwrap\n  \
+                    Maintenance  upgrade · watch · rotate · open",
     version
 )]
 struct Cli {
@@ -31,14 +37,97 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    // ───────────────────────────── Setup ─────────────────────────────
     /// Import .env secrets into the vault and rewrite with phantom tokens
+    #[command(next_help_heading = "Setup")]
     Init {
         /// Path to .env file. Auto-detects .env, .env.local, .env.development and searches subdirectories
         #[arg(short, long, default_value = ".env")]
         from: String,
+        /// Protect every git repo with a .env under <DIR> in one go.
+        /// Skips repos that already have .phantom.toml.
+        #[arg(long, value_name = "DIR")]
+        all: Option<std::path::PathBuf>,
+        /// With --all: scan and report what would change without modifying anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Wire Phantom into an AI client (Claude Code, Cursor, Windsurf, Codex)
+    #[command(next_help_heading = "Setup")]
+    Setup {
+        /// AI client to configure. Defaults to Claude Code if omitted.
+        #[arg(value_enum, long, short = 'c')]
+        client: Option<commands::setup::Client>,
+        /// Print the config snippet to stdout instead of writing files
+        #[arg(long)]
+        print: bool,
+    },
+
+    /// Check configuration and vault health
+    #[command(next_help_heading = "Setup")]
+    Doctor {
+        /// Auto-fix safe issues (install hooks, generate .env.example, etc.)
+        #[arg(long)]
+        fix: bool,
+    },
+
+    /// Print a shell-completion script to stdout.
+    ///
+    /// Source the output from your shell rc, e.g.
+    ///   bash:       phantom completion bash > ~/.local/share/bash-completion/completions/phantom
+    ///   zsh:        phantom completion zsh > "${fpath[1]}/_phantom"
+    ///   fish:       phantom completion fish > ~/.config/fish/completions/phantom.fish
+    ///   powershell: phantom completion powershell | Out-String | Invoke-Expression
+    #[command(next_help_heading = "Setup")]
+    Completion {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
+
+    // ─────────────────────────── Daily use ───────────────────────────
+    /// Start the proxy and run a command
+    #[command(next_help_heading = "Daily use")]
+    Exec {
+        /// Command and arguments to run
+        #[arg(trailing_var_arg = true, required = true)]
+        cmd: Vec<String>,
+    },
+
+    /// Start the proxy server
+    #[command(next_help_heading = "Daily use")]
+    Start {
+        /// Run in background (daemon mode)
+        #[arg(short, long)]
+        daemon: bool,
+    },
+
+    /// Stop the background proxy server
+    #[command(next_help_heading = "Daily use")]
+    Stop,
+
+    /// Show proxy status and mapped secrets
+    #[command(next_help_heading = "Daily use")]
+    Status {
+        /// Compact one-line output for shell prompts (e.g., "3 secrets · proxy off")
+        #[arg(long)]
+        oneline: bool,
+    },
+
+    /// Check for unprotected secrets (pre-commit hook)
+    #[command(next_help_heading = "Daily use")]
+    Check {
+        /// Only scan git-staged files (skip .env scanning, faster for pre-commit hooks)
+        #[arg(long)]
+        staged: bool,
+        /// Check if phantom tokens are in environment without proxy running
+        #[arg(long)]
+        runtime: bool,
     },
 
     /// List stored secret names (never shows values)
+    #[command(next_help_heading = "Daily use")]
     List {
         /// Emit JSON instead of the human-readable table
         #[arg(long)]
@@ -46,6 +135,7 @@ enum Commands {
     },
 
     /// Add a secret to the vault
+    #[command(next_help_heading = "Daily use")]
     Add {
         /// Secret name (e.g., OPENAI_API_KEY)
         name: String,
@@ -58,12 +148,14 @@ enum Commands {
     },
 
     /// Remove a secret from the vault
+    #[command(next_help_heading = "Daily use")]
     Remove {
         /// Secret name to remove
         name: String,
     },
 
     /// Reveal a secret value (print to stdout or copy to clipboard)
+    #[command(next_help_heading = "Daily use")]
     Reveal {
         /// Secret name to reveal
         name: String,
@@ -75,55 +167,59 @@ enum Commands {
         yes: bool,
     },
 
-    /// Show proxy status and mapped secrets
-    Status {
-        /// Compact one-line output for shell prompts (e.g., "3 secrets · proxy off")
+    /// Copy a secret from this project's vault to another project
+    #[command(next_help_heading = "Daily use")]
+    Copy {
+        /// Secret name in this project
+        name: String,
+        /// Target project directory
         #[arg(long)]
-        oneline: bool,
+        to: std::path::PathBuf,
+        /// Rename the secret in the target project
+        #[arg(long, alias = "as")]
+        rename: Option<String>,
     },
 
-    /// Regenerate phantom tokens (invalidates old ones)
-    Rotate {
-        /// Also sync secrets to all configured deployment platforms after rotation
-        #[arg(long)]
-        sync: bool,
+    /// Generate .env.example for team onboarding
+    #[command(next_help_heading = "Daily use")]
+    Env {
+        /// Output file name (defaults to .env.example)
+        #[arg(short, long, default_value = ".env.example")]
+        output: String,
     },
 
-    /// Check configuration and vault health
-    Doctor {
-        /// Auto-fix safe issues (install hooks, generate .env.example, etc.)
-        #[arg(long)]
-        fix: bool,
+    /// Explain why a key is or isn't protected
+    #[command(next_help_heading = "Daily use")]
+    Why {
+        /// Environment variable name to explain
+        key: String,
     },
 
-    /// Start the proxy and run a command
-    Exec {
-        /// Command and arguments to run
-        #[arg(trailing_var_arg = true, required = true)]
-        cmd: Vec<String>,
+    // ───────────────────────── Sync & teams ──────────────────────────
+    /// Log in to Phantom Cloud
+    #[command(next_help_heading = "Sync & teams")]
+    Login,
+
+    /// Log out of Phantom Cloud
+    #[command(next_help_heading = "Sync & teams")]
+    Logout,
+
+    /// Cloud vault sync commands
+    #[command(next_help_heading = "Sync & teams")]
+    Cloud {
+        #[command(subcommand)]
+        action: CloudAction,
     },
 
-    /// Start the proxy server
-    Start {
-        /// Run in background (daemon mode)
-        #[arg(short, long)]
-        daemon: bool,
-    },
-
-    /// Stop the background proxy server
-    Stop,
-
-    /// Check for unprotected secrets (pre-commit hook)
-    Check {
-        /// Only scan git-staged files (skip .env scanning, faster for pre-commit hooks)
-        #[arg(long)]
-        staged: bool,
-        /// Check if phantom tokens are in environment without proxy running
-        #[arg(long)]
-        runtime: bool,
+    /// Team vault management
+    #[command(next_help_heading = "Sync & teams")]
+    Team {
+        #[command(subcommand)]
+        action: TeamAction,
     },
 
     /// Sync secrets to deployment platforms (Vercel, Railway)
+    #[command(next_help_heading = "Sync & teams")]
     Sync {
         /// Platform to sync to (vercel, railway). Syncs all configured targets if omitted.
         #[arg(short, long)]
@@ -139,6 +235,7 @@ enum Commands {
     },
 
     /// Pull secrets from a deployment platform into the vault
+    #[command(next_help_heading = "Sync & teams")]
     Pull {
         /// Platform to pull from (vercel, railway)
         #[arg(long)]
@@ -157,17 +254,8 @@ enum Commands {
         force: bool,
     },
 
-    /// Set up Phantom auto-mode for Claude Code (MCP server + hooks)
-    Setup,
-
-    /// Generate .env.example for team onboarding
-    Env {
-        /// Output file name (defaults to .env.example)
-        #[arg(short, long, default_value = ".env.example")]
-        output: String,
-    },
-
     /// Export secrets to an encrypted backup file
+    #[command(next_help_heading = "Sync & teams")]
     Export {
         /// Output file path
         #[arg(short, long, default_value = "phantom-export.enc")]
@@ -178,6 +266,7 @@ enum Commands {
     },
 
     /// Import secrets from an encrypted backup file
+    #[command(next_help_heading = "Sync & teams")]
     Import {
         /// Path to the encrypted backup file
         file: String,
@@ -189,25 +278,8 @@ enum Commands {
         force: bool,
     },
 
-    /// Log in to Phantom Cloud
-    Login,
-
-    /// Log out of Phantom Cloud
-    Logout,
-
-    /// Cloud vault sync commands
-    Cloud {
-        #[command(subcommand)]
-        action: CloudAction,
-    },
-
-    /// Team vault management
-    Team {
-        #[command(subcommand)]
-        action: TeamAction,
-    },
-
     /// Wrap package.json scripts with `phantom exec` (no more manual prefix)
+    #[command(next_help_heading = "Sync & teams")]
     Wrap {
         /// Only wrap specific scripts (by name)
         #[arg(long)]
@@ -218,43 +290,12 @@ enum Commands {
     },
 
     /// Unwrap package.json scripts (restore originals from :raw variants)
+    #[command(next_help_heading = "Sync & teams")]
     Unwrap,
 
-    /// Watch .env files and auto-detect new unprotected secrets
-    Watch {
-        /// Auto-protect new secrets without prompting
-        #[arg(long)]
-        auto: bool,
-    },
-
-    /// Explain why a key is or isn't protected
-    Why {
-        /// Environment variable name to explain
-        key: String,
-    },
-
-    /// Copy a secret from this project's vault to another project
-    Copy {
-        /// Secret name in this project
-        name: String,
-        /// Target project directory
-        #[arg(long)]
-        to: std::path::PathBuf,
-        /// Rename the secret in the target project
-        #[arg(long, alias = "as")]
-        rename: Option<String>,
-    },
-
-    /// Open a Phantom page in the browser. Defaults to the dashboard.
-    /// Aliases: dashboard, billing, team, docs, pricing, github, issues, site.
-    /// Any other word becomes https://phm.dev/<word>; full URLs pass through.
-    Open {
-        /// What to open. Defaults to the dashboard if omitted.
-        #[arg(default_value = "")]
-        target: String,
-    },
-
+    // ───────────────────────── Maintenance ───────────────────────────
     /// Self-replace this binary with the latest GitHub release.
+    #[command(next_help_heading = "Maintenance")]
     Upgrade {
         /// Skip confirmation prompt and upgrade immediately
         #[arg(long)]
@@ -264,17 +305,30 @@ enum Commands {
         check_only: bool,
     },
 
-    /// Print a shell-completion script to stdout.
-    ///
-    /// Source the output from your shell rc, e.g.
-    ///   bash:       phantom completion bash > ~/.local/share/bash-completion/completions/phantom
-    ///   zsh:        phantom completion zsh > "${fpath[1]}/_phantom"
-    ///   fish:       phantom completion fish > ~/.config/fish/completions/phantom.fish
-    ///   powershell: phantom completion powershell | Out-String | Invoke-Expression
-    Completion {
-        /// Shell to generate completions for
-        #[arg(value_enum)]
-        shell: clap_complete::Shell,
+    /// Watch .env files and auto-detect new unprotected secrets
+    #[command(next_help_heading = "Maintenance")]
+    Watch {
+        /// Auto-protect new secrets without prompting
+        #[arg(long)]
+        auto: bool,
+    },
+
+    /// Regenerate phantom tokens (invalidates old ones)
+    #[command(next_help_heading = "Maintenance")]
+    Rotate {
+        /// Also sync secrets to all configured deployment platforms after rotation
+        #[arg(long)]
+        sync: bool,
+    },
+
+    /// Open a Phantom page in the browser. Defaults to the dashboard.
+    /// Aliases: dashboard, billing, team, docs, pricing, github, issues, site.
+    /// Any other word becomes https://phm.dev/<word>; full URLs pass through.
+    #[command(next_help_heading = "Maintenance")]
+    Open {
+        /// What to open. Defaults to the dashboard if omitted.
+        #[arg(default_value = "")]
+        target: String,
     },
 
     /// Internal: clear the system clipboard after N seconds. Spawned by
@@ -362,7 +416,10 @@ fn main() -> anyhow::Result<()> {
         .init();
 
     match cli.command {
-        Commands::Init { from } => commands::init::run(&from),
+        Commands::Init { from, all, dry_run } => match all {
+            Some(root) => commands::init::multi::run(root, dry_run),
+            None => commands::init::run(&from),
+        },
         Commands::List { json } => commands::list::run(json),
         Commands::Add { name, value, stdin } => commands::add::run(&name, value.as_deref(), stdin),
         Commands::Remove { name } => commands::remove::run(&name),
@@ -385,7 +442,7 @@ fn main() -> anyhow::Result<()> {
             service,
             force,
         } => commands::pull::run(&from, &project, environment, service, force),
-        Commands::Setup => commands::setup::run(),
+        Commands::Setup { client, print } => commands::setup::run(client, print),
         Commands::Sync {
             platform,
             project,

--- a/crates/phantom-cli/src/util.rs
+++ b/crates/phantom-cli/src/util.rs
@@ -1,0 +1,11 @@
+use colored::Colorize;
+
+/// Render a "Docs: https://phm.dev/docs/<slug>" suffix in a consistent style.
+/// Use as the trailing line of a user-visible error so people can self-serve
+/// the fix without context-switching to search.
+pub fn docs_url(slug: &str) -> String {
+    format!(
+        "Docs: {}",
+        format!("https://phm.dev/docs/{slug}").cyan().underline()
+    )
+}

--- a/crates/phantom-core/src/audit.rs
+++ b/crates/phantom-core/src/audit.rs
@@ -1,0 +1,248 @@
+//! Opt-in audit log for vault and sync operations.
+//!
+//! Writes one JSON object per line to `~/.phantom/audit.log`. Disabled by
+//! default; turn on by exporting `PHANTOM_AUDIT=1`. The log records the
+//! **name** of secrets accessed (for forensics) but never the **value** —
+//! values must never appear in the log under any circumstance.
+//!
+//! Schema (per line):
+//! ```json
+//! {"ts": 1714794600, "op": "vault.store", "name": "OPENAI_API_KEY",
+//!  "process": "phantom", "pid": 12345}
+//! ```
+//!
+//! `ts` is seconds since the UNIX epoch. `name` is omitted for ops that
+//! don't operate on a single named secret (e.g. `cloud.push`).
+
+use serde::Serialize;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Returns true if audit logging is currently enabled.
+pub fn enabled() -> bool {
+    std::env::var("PHANTOM_AUDIT")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "True"))
+        .unwrap_or(false)
+}
+
+/// Log an audit event. Best-effort: errors are swallowed so audit failures
+/// can never break a vault op. No-op when [`enabled`] is false.
+///
+/// # Important
+/// `name` MUST be a secret name (e.g. `OPENAI_API_KEY`), never a secret
+/// value. Callers in security-sensitive code paths must not pass values.
+pub fn log(op: &str, name: Option<&str>) {
+    if !enabled() {
+        return;
+    }
+    let _ = write_event(op, name);
+}
+
+fn write_event(op: &str, name: Option<&str>) -> std::io::Result<()> {
+    let path = log_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let event = AuditEvent {
+        ts: now_unix(),
+        op: op.to_string(),
+        name: name.map(|s| s.to_string()),
+        process: process_name(),
+        pid: std::process::id(),
+    };
+
+    let mut line = serde_json::to_vec(&event)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    line.push(b'\n');
+
+    // OpenOptions::append on Linux/macOS gives O_APPEND atomicity for
+    // writes <= PIPE_BUF (~4096 bytes) which our JSONL lines easily fit
+    // under, so we don't take an explicit lock. Windows append semantics
+    // are similar with FILE_APPEND_DATA.
+    let mut f = OpenOptions::new().append(true).create(true).open(&path)?;
+    f.write_all(&line)?;
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct AuditEvent {
+    ts: u64,
+    op: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    process: String,
+    pid: u32,
+}
+
+fn log_path() -> std::io::Result<PathBuf> {
+    if let Some(home) = dirs_home_dir() {
+        Ok(home.join(".phantom").join("audit.log"))
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "could not resolve home directory",
+        ))
+    }
+}
+
+fn dirs_home_dir() -> Option<PathBuf> {
+    if let Ok(h) = std::env::var("HOME") {
+        if !h.is_empty() {
+            return Some(PathBuf::from(h));
+        }
+    }
+    if let Ok(h) = std::env::var("USERPROFILE") {
+        if !h.is_empty() {
+            return Some(PathBuf::from(h));
+        }
+    }
+    None
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn process_name() -> String {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.file_name().map(|s| s.to_string_lossy().into_owned()))
+        .unwrap_or_else(|| "phantom".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use std::sync::Mutex;
+    use tempfile::tempdir;
+
+    /// All tests in this module mutate process-wide env vars
+    /// (`PHANTOM_AUDIT`, `HOME`). cargo runs unit tests in parallel by
+    /// default within a test binary, so we serialize via this mutex to
+    /// keep them deterministic without a `serial_test` dependency.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_temp_home<F: FnOnce()>(env: &str, val: &str, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var(env).ok();
+        // SAFETY: env mutation is serialized via ENV_LOCK above.
+        unsafe {
+            std::env::set_var(env, val);
+        }
+        f();
+        unsafe {
+            match prev {
+                Some(p) => std::env::set_var(env, p),
+                None => std::env::remove_var(env),
+            }
+        }
+    }
+
+    #[test]
+    fn disabled_by_default() {
+        with_temp_home("PHANTOM_AUDIT", "", || {
+            assert!(!enabled());
+        });
+    }
+
+    #[test]
+    fn enabled_when_env_set_to_one() {
+        with_temp_home("PHANTOM_AUDIT", "1", || {
+            assert!(enabled());
+        });
+    }
+
+    #[test]
+    fn writes_jsonl_line_when_enabled() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempdir().unwrap();
+        let prev_home = std::env::var("HOME").ok();
+        let prev_audit = std::env::var("PHANTOM_AUDIT").ok();
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("PHANTOM_AUDIT", "1");
+        }
+
+        log("vault.store", Some("OPENAI_API_KEY"));
+        log("cloud.push", None);
+
+        let path = tmp.path().join(".phantom").join("audit.log");
+        let content = std::fs::read_to_string(&path).expect("audit.log should exist");
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let line0: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(line0["op"], "vault.store");
+        assert_eq!(line0["name"], "OPENAI_API_KEY");
+        assert!(line0["pid"].is_number());
+        assert!(line0["ts"].is_number());
+
+        let line1: Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(line1["op"], "cloud.push");
+        assert!(
+            line1.get("name").is_none(),
+            "name should be omitted for None"
+        );
+
+        unsafe {
+            match prev_home {
+                Some(p) => std::env::set_var("HOME", p),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_audit {
+                Some(p) => std::env::set_var("PHANTOM_AUDIT", p),
+                None => std::env::remove_var("PHANTOM_AUDIT"),
+            }
+        }
+    }
+
+    #[test]
+    fn no_file_written_when_disabled() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempdir().unwrap();
+        let prev_home = std::env::var("HOME").ok();
+        let prev_audit = std::env::var("PHANTOM_AUDIT").ok();
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::remove_var("PHANTOM_AUDIT");
+        }
+
+        log("vault.store", Some("X"));
+        let path = tmp.path().join(".phantom").join("audit.log");
+        assert!(!path.exists(), "should not write when disabled");
+
+        unsafe {
+            match prev_home {
+                Some(p) => std::env::set_var("HOME", p),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_audit {
+                Some(p) => std::env::set_var("PHANTOM_AUDIT", p),
+                None => std::env::remove_var("PHANTOM_AUDIT"),
+            }
+        }
+    }
+
+    /// Defensive sanity: log() should NEVER write the value. We don't have
+    /// a typed "value" parameter to begin with, but assert the schema's
+    /// serialized form has no `value` key.
+    #[test]
+    fn schema_has_no_value_field() {
+        let event = AuditEvent {
+            ts: 0,
+            op: "vault.store".to_string(),
+            name: Some("KEY".to_string()),
+            process: "phantom".to_string(),
+            pid: 1,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert!(json.get("value").is_none());
+    }
+}

--- a/crates/phantom-core/src/lib.rs
+++ b/crates/phantom-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod audit;
 pub mod auth;
 pub mod cloud;
 pub mod config;

--- a/crates/phantom-vault/src/crypto.rs
+++ b/crates/phantom-vault/src/crypto.rs
@@ -1,4 +1,4 @@
-use argon2::Argon2;
+use argon2::{Algorithm, Argon2, Params, Version};
 use chacha20poly1305::{
     aead::{Aead, KeyInit},
     ChaCha20Poly1305, Nonce,
@@ -14,11 +14,33 @@ const KEY_LEN: usize = 32;
 /// Minimum size of an encrypted blob: salt + nonce + at least 1 byte of ciphertext.
 pub const MIN_ENCRYPTED_LEN: usize = SALT_LEN + NONCE_LEN + 1;
 
+/// Hardened Argon2id parameters (OWASP "balanced" recommendation, 2024+):
+/// 64 MiB memory, 3 iterations, 1 lane, 32-byte output.
+fn hardened_argon2() -> Result<Argon2<'static>> {
+    let params = Params::new(64 * 1024, 3, 1, Some(KEY_LEN))
+        .map_err(|e| PhantomError::VaultError(format!("Argon2 params: {e}")))?;
+    Ok(Argon2::new(Algorithm::Argon2id, Version::V0x13, params))
+}
+
+/// Derive a key using the current (hardened) Argon2id parameters. Used for
+/// every new encryption.
 fn derive_key(passphrase: &str, salt: &[u8]) -> Result<[u8; KEY_LEN]> {
+    let mut key = [0u8; KEY_LEN];
+    hardened_argon2()?
+        .hash_password_into(passphrase.as_bytes(), salt, &mut key)
+        .map_err(|e| PhantomError::VaultError(format!("Key derivation failed: {e}")))?;
+    Ok(key)
+}
+
+/// Derive a key using legacy `Argon2::default()` parameters. Tried as a
+/// fallback when [`derive_key`] produces a key that doesn't decrypt — this
+/// preserves compatibility with vaults encrypted under earlier phantom
+/// releases (m=19MiB / t=2 / p=1, the argon2 crate's default).
+fn derive_key_legacy(passphrase: &str, salt: &[u8]) -> Result<[u8; KEY_LEN]> {
     let mut key = [0u8; KEY_LEN];
     Argon2::default()
         .hash_password_into(passphrase.as_bytes(), salt, &mut key)
-        .map_err(|e| PhantomError::VaultError(format!("Key derivation failed: {e}")))?;
+        .map_err(|e| PhantomError::VaultError(format!("Legacy key derivation failed: {e}")))?;
     Ok(key)
 }
 
@@ -62,18 +84,38 @@ pub fn decrypt(encrypted: &[u8], passphrase: &str) -> Result<Vec<u8>> {
     let salt = &encrypted[..SALT_LEN];
     let nonce_bytes = &encrypted[SALT_LEN..SALT_LEN + NONCE_LEN];
     let ciphertext = &encrypted[SALT_LEN + NONCE_LEN..];
+    let nonce = Nonce::from_slice(nonce_bytes);
 
-    let mut key = derive_key(passphrase, salt)?;
+    // Try the hardened parameters first; if AEAD verification fails we
+    // fall back to legacy `Argon2::default()` to keep older vaults
+    // decryptable. Either path's key is zeroized before this fn returns.
+    if let Some(plaintext) = try_decrypt_with(derive_key, passphrase, salt, nonce, ciphertext)? {
+        return Ok(plaintext);
+    }
+    if let Some(plaintext) =
+        try_decrypt_with(derive_key_legacy, passphrase, salt, nonce, ciphertext)?
+    {
+        return Ok(plaintext);
+    }
+
+    Err(PhantomError::VaultError(
+        "Decryption failed — wrong passphrase or corrupt data".to_string(),
+    ))
+}
+
+fn try_decrypt_with(
+    derive: fn(&str, &[u8]) -> Result<[u8; KEY_LEN]>,
+    passphrase: &str,
+    salt: &[u8],
+    nonce: &Nonce,
+    ciphertext: &[u8],
+) -> Result<Option<Vec<u8>>> {
+    let mut key = derive(passphrase, salt)?;
     let cipher = ChaCha20Poly1305::new_from_slice(&key)
         .map_err(|e| PhantomError::VaultError(format!("Cipher init failed: {e}")))?;
     key.zeroize();
 
-    let nonce = Nonce::from_slice(nonce_bytes);
-    let plaintext = cipher.decrypt(nonce, ciphertext).map_err(|_| {
-        PhantomError::VaultError("Decryption failed — wrong passphrase or corrupt data".to_string())
-    })?;
-
-    Ok(plaintext)
+    Ok(cipher.decrypt(nonce, ciphertext).ok())
 }
 
 #[cfg(test)]
@@ -113,5 +155,46 @@ mod tests {
         // But both decrypt to the same thing
         assert_eq!(decrypt(&e1, "pass").unwrap(), plaintext);
         assert_eq!(decrypt(&e2, "pass").unwrap(), plaintext);
+    }
+
+    /// Encrypt with the legacy KDF, then verify the current `decrypt` path
+    /// can still read it. This guarantees we never break older vaults when
+    /// we tighten Argon2 parameters.
+    #[test]
+    fn test_legacy_vault_still_decrypts() {
+        use chacha20poly1305::aead::{Aead, KeyInit};
+        let plaintext = b"old-vault-data";
+        let passphrase = "legacy-pass";
+
+        let mut salt = [0u8; SALT_LEN];
+        let mut nonce_bytes = [0u8; NONCE_LEN];
+        rand::thread_rng().fill_bytes(&mut salt);
+        rand::thread_rng().fill_bytes(&mut nonce_bytes);
+
+        let mut key = derive_key_legacy(passphrase, &salt).unwrap();
+        let cipher = ChaCha20Poly1305::new_from_slice(&key).unwrap();
+        key.zeroize();
+
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let ct = cipher.encrypt(nonce, plaintext.as_ref()).unwrap();
+
+        let mut blob = Vec::with_capacity(SALT_LEN + NONCE_LEN + ct.len());
+        blob.extend_from_slice(&salt);
+        blob.extend_from_slice(&nonce_bytes);
+        blob.extend_from_slice(&ct);
+
+        // Real path — should hit the legacy fallback after the hardened
+        // params produce a non-matching key.
+        assert_eq!(decrypt(&blob, passphrase).unwrap(), plaintext);
+    }
+
+    #[test]
+    fn test_hardened_and_legacy_keys_differ() {
+        // Sanity check that the two derivations are actually different —
+        // otherwise the legacy fallback would be silently dead code.
+        let salt = [42u8; SALT_LEN];
+        let h = derive_key("same-pass", &salt).unwrap();
+        let l = derive_key_legacy("same-pass", &salt).unwrap();
+        assert_ne!(h, l);
     }
 }

--- a/crates/phantom-vault/src/file.rs
+++ b/crates/phantom-vault/src/file.rs
@@ -140,16 +140,19 @@ impl VaultBackend for FileVault {
         let mut data = self.load()?;
         data.secrets.insert(name.to_string(), value.to_string());
         self.save(&data)?;
+        phantom_core::audit::log("vault.store", Some(name));
         Ok(())
     }
 
     fn retrieve(&self, name: &str) -> Result<zeroize::Zeroizing<String>> {
         let data = self.load()?;
-        data.secrets
+        let value = data
+            .secrets
             .get(name)
             .cloned()
-            .map(zeroize::Zeroizing::new)
-            .ok_or_else(|| PhantomError::SecretNotFound(name.to_string()))
+            .ok_or_else(|| PhantomError::SecretNotFound(name.to_string()))?;
+        phantom_core::audit::log("vault.retrieve", Some(name));
+        Ok(zeroize::Zeroizing::new(value))
     }
 
     fn delete(&self, name: &str) -> Result<()> {
@@ -159,6 +162,7 @@ impl VaultBackend for FileVault {
             return Err(PhantomError::SecretNotFound(name.to_string()));
         }
         self.save(&data)?;
+        phantom_core::audit::log("vault.delete", Some(name));
         Ok(())
     }
 

--- a/crates/phantom-vault/src/keychain.rs
+++ b/crates/phantom-vault/src/keychain.rs
@@ -148,13 +148,17 @@ impl VaultBackend for KeychainVault {
             index.sort();
             self.save_index(&index)?;
         }
+        phantom_core::audit::log("vault.store", Some(name));
         Ok(())
     }
 
     fn retrieve(&self, name: &str) -> Result<zeroize::Zeroizing<String>> {
         let entry = self.entry_for(name)?;
         match entry.get_password() {
-            Ok(value) => Ok(zeroize::Zeroizing::new(value)),
+            Ok(value) => {
+                phantom_core::audit::log("vault.retrieve", Some(name));
+                Ok(zeroize::Zeroizing::new(value))
+            }
             Err(keyring::Error::NoEntry) => {
                 // F13 migration: older phantom versions stored entries under
                 // the plaintext name. If we find one, return its value and
@@ -167,6 +171,7 @@ impl VaultBackend for KeychainVault {
                                 let _ = new_entry.set_password(&value);
                             }
                             let _ = legacy.delete_credential();
+                            phantom_core::audit::log("vault.retrieve", Some(name));
                             Ok(zeroize::Zeroizing::new(value))
                         }
                         Err(keyring::Error::NoEntry) => {
@@ -220,11 +225,13 @@ impl VaultBackend for KeychainVault {
         index.retain(|n| n != name);
         if was_in_index {
             self.save_index(&index)?;
+            phantom_core::audit::log("vault.delete", Some(name));
             Ok(())
         } else if matches!(new_result, Err(keyring::Error::NoEntry)) {
             Err(PhantomError::SecretNotFound(name.to_string()))
         } else {
             self.save_index(&index)?;
+            phantom_core::audit::log("vault.delete", Some(name));
             Ok(())
         }
     }
@@ -283,5 +290,35 @@ mod tests {
             h.chars().all(|c| c.is_ascii_hexdigit()),
             "expected lowercase hex: {h}"
         );
+    }
+
+    /// End-to-end round-trip against the real OS keychain. Ignored by
+    /// default because it touches the user's actual keychain (and CI
+    /// may not have one without `keyring`'s mock backend). Run with
+    /// `cargo test -p phantom-secrets-vault -- --ignored` on each
+    /// platform (macOS Keychain, Linux Secret Service, Windows
+    /// Credential Manager) to confirm the backend is wired up.
+    #[test]
+    #[ignore = "touches OS keychain — run with --ignored on each platform"]
+    fn os_keychain_roundtrip() {
+        use crate::traits::VaultBackend;
+
+        // Per-run unique project_id so a previous failed run can't
+        // pollute this one's state.
+        let project_id = format!("phantom-test-{}", std::process::id());
+        let vault = KeychainVault::new(&project_id).expect("keychain backend should initialize");
+
+        let name = "ROUNDTRIP_TEST_KEY";
+        let value = "sk-test-value-do-not-use-12345";
+        vault.store(name, value).expect("store");
+
+        let got = vault.retrieve(name).expect("retrieve");
+        assert_eq!(got.as_str(), value);
+
+        let listed = vault.list().expect("list");
+        assert!(listed.iter().any(|n| n == name));
+
+        vault.delete(name).expect("delete");
+        assert!(vault.retrieve(name).is_err());
     }
 }

--- a/npm/bin/cli.js
+++ b/npm/bin/cli.js
@@ -67,11 +67,35 @@ function parseSha256File(buf, expectedFilename) {
   return m[1].toLowerCase();
 }
 
+function isCachedBinaryStale(binaryPath) {
+  // The cached binary is "stale" when its `--version` output doesn't include
+  // the version the npm wrapper was published with. This catches the
+  // common case: user ran `npm i -g phantom-secrets@latest`, the wrapper
+  // updated to a newer VERSION, but the cached binary is still the old one.
+  try {
+    const out = execFileSync(binaryPath, ["--version"], { stdio: ["ignore", "pipe", "ignore"] });
+    return !out.toString().includes(VERSION);
+  } catch {
+    // If we can't even invoke the binary, treat as stale.
+    return true;
+  }
+}
+
 async function ensureBinary() {
   const binaryPath = getBinaryPath();
 
   if (existsSync(binaryPath)) {
-    return binaryPath;
+    if (!isCachedBinaryStale(binaryPath)) {
+      return binaryPath;
+    }
+    console.error(
+      `Cached phantom is out of date — refreshing to v${VERSION}...`
+    );
+    try {
+      unlinkSync(binaryPath);
+    } catch {
+      // best-effort: if we can't delete, the download below will overwrite anyway.
+    }
   }
 
   const target = getPlatformTarget();


### PR DESCRIPTION
## Summary

Eight focused improvements landing as one branch, organized into two tracks. Each section is small enough to review independently.

### Track A — UX & onboarding polish
- **A1** — `--help` now groups commands by purpose: Setup · Daily use · Sync & teams · Maintenance, with a legend at the top of `long_about` so the four groups are immediately visible.
- **A2** — `phantom setup --client cursor|windsurf|codex|claude` plus `--print` for stdout. Auto-falls back to `npx -y phantom-secrets-mcp` when `phantom-mcp` isn't on PATH so configs always work on a fresh machine. 5 unit tests cover the JSON writers.
- **A3** — `phantom init --all <DIR>` walks a workspace, finds every git repo with a `.env`, runs init in each. `--dry-run` previews. Skips `node_modules`/`target`/dot-dirs. 5 unit tests.
- **A4** — `phantom upgrade` detects npm-installed phantom and redirects to `npm i -g phantom-secrets@latest` (preventing the next `npm install` from reverting the upgrade). The npm wrapper now invalidates its cached binary when its `--version` doesn't match the wrapper's published `VERSION`.
- **A5** — `phantom init` next-steps now include a pre-commit hook setup line and a hint for non-Claude AI tools.
- **A6** — `phantom team invite` prints a copy-paste-ready 4-step onboarding checklist for the invitee (install → login → key-publish → vault-pull).
- **A7** — New `crates/phantom-cli/src/util.rs::docs_url(slug)` helper. Appended `Docs: https://phm.dev/docs/<slug>` to the 6 highest-traffic error paths (no .env, no .phantom.toml, login timeout).

### Track B — Security cheap wins
- **B1** — Argon2id hardened to OWASP "balanced" params (m=64 MiB, t=3, p=1) for all new encryptions. `derive_key_legacy` retains `Argon2::default()`; `decrypt()` tries hardened first and falls back to legacy, so existing vaults still open. Two new tests verify the legacy-vault round-trip and that the two derivations actually differ.
- **B2** — Verified the `keyring` crate already ships with `windows-native` enabled and there are zero `cfg(target_os = "windows")` guards. Windows Credential Manager is **already supported**. Added an `#[ignore]`-by-default OS-keychain round-trip test runnable on any platform via `cargo test -p phantom-secrets-vault -- --ignored`.
- **B3** — `phantom-core/src/audit.rs`: opt-in JSONL audit log at `~/.phantom/audit.log`, off by default, enabled with `PHANTOM_AUDIT=1`. Hooked into vault `store/retrieve/delete` for both keychain and file backends. Schema enforces no `value` field — only the secret name is recorded. 5 tests, serialized via static `Mutex` to avoid env-var contention.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 182 tests pass, 4 intentionally ignored (3 doctests + 1 OS-keychain round-trip), 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Smoke-tested `phantom setup --client cursor|codex|windsurf --print` produces correct config snippets
- [x] Smoke-tested `phantom init --all /tmp/<dir> --dry-run` discovers fake repos correctly
- [ ] Manual verification on Windows for the credential-manager backend (run `cargo test -- --ignored` on a Windows runner)
- [ ] Manual verification of `phantom upgrade` flow on an npm-installed install vs. brew-installed install

## Commit shape
Single squash-friendly commit grouped by track. Happy to split into 8 separate PRs (A1–A7, B1–B3) if reviewers prefer atomic-PR cadence — each work item is already self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)