### PR TITLE
feat: phantom mcp serve bundles MCP server into main binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,7 @@ dependencies = [
  "notify",
  "open",
  "phantom-secrets-core",
+ "phantom-secrets-mcp",
  "phantom-secrets-proxy",
  "phantom-secrets-vault",
  "rpassword",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ base64 = "0.22"
 phantom-core = { path = "crates/phantom-core", version = "0.5.1", package = "phantom-secrets-core" }
 phantom-vault = { path = "crates/phantom-vault", version = "0.5.1", package = "phantom-secrets-vault" }
 phantom-proxy = { path = "crates/phantom-proxy", version = "0.5.1", package = "phantom-secrets-proxy" }
+phantom-mcp = { path = "crates/phantom-mcp", version = "0.5.1", package = "phantom-secrets-mcp" }

--- a/crates/phantom-cli/Cargo.toml
+++ b/crates/phantom-cli/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 phantom-core = { workspace = true }
 phantom-vault = { workspace = true }
 phantom-proxy = { workspace = true }
+phantom-mcp = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 tokio = { workspace = true }

--- a/crates/phantom-cli/src/commands/mcp.rs
+++ b/crates/phantom-cli/src/commands/mcp.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+
+pub fn run_serve() -> Result<()> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(phantom_mcp::run_stdio_server())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    /// Minimal harness: just enough of the CLI to verify `phantom mcp serve` parses cleanly.
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        command: TestCommands,
+    }
+
+    #[derive(clap::Subcommand)]
+    enum TestCommands {
+        Mcp {
+            #[command(subcommand)]
+            action: McpAction,
+        },
+    }
+
+    #[derive(clap::Subcommand)]
+    enum McpAction {
+        Serve,
+    }
+
+    #[test]
+    fn mcp_serve_parses() {
+        let cli = TestCli::try_parse_from(["phantom", "mcp", "serve"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            TestCommands::Mcp {
+                action: McpAction::Serve
+            }
+        ));
+    }
+}

--- a/crates/phantom-cli/src/commands/mod.rs
+++ b/crates/phantom-cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod init;
 pub mod list;
 pub mod login;
 pub mod logout;
+pub mod mcp;
 pub mod open;
 pub mod pull;
 pub mod remove;

--- a/crates/phantom-cli/src/commands/setup.rs
+++ b/crates/phantom-cli/src/commands/setup.rs
@@ -60,8 +60,14 @@ pub fn run(client: Option<Client>, print: bool) -> Result<()> {
     );
     if mcp.command == "npx" {
         println!(
-            "   {} phantom-mcp not on PATH — using `npx -y phantom-secrets-mcp` as fallback.",
+            "   {} phantom-mcp not found — using `npx -y phantom-secrets-mcp` as fallback.",
             "note".dimmed()
+        );
+    } else if mcp.args.first().map(|a| a == "mcp").unwrap_or(false) {
+        println!(
+            "   {} using bundled MCP server ({} mcp serve)",
+            "note".dimmed(),
+            mcp.command.dimmed()
         );
     }
 
@@ -73,20 +79,34 @@ pub fn run(client: Option<Client>, print: bool) -> Result<()> {
     }
 }
 
-/// Resolve the command + args we want each MCP client to invoke. Prefers a
-/// real `phantom-mcp` binary on disk; falls back to `npx -y phantom-secrets-mcp`
-/// when nothing is found, so the config still works on a fresh machine.
+/// Resolve the command + args we want each MCP client to invoke.
+///
+/// Resolution order:
+///   1. Current executable + `["mcp", "serve"]` — the bundled in-process server
+///      (always preferred: one binary, no PATH dependency).
+///   2. `phantom-mcp` binary on PATH or next to the current exe — legacy standalone.
+///   3. `npx -y phantom-secrets-mcp` — works on a machine that only has Node/npm.
 fn mcp_command_spec() -> McpCommand {
+    // (1) Prefer the bundled subcommand in the current binary.
+    if let Ok(exe) = std::env::current_exe() {
+        return McpCommand {
+            command: exe.to_string_lossy().into_owned(),
+            args: vec!["mcp".to_string(), "serve".to_string()],
+        };
+    }
+
+    // (2) Fall back to a separate phantom-mcp binary on disk / PATH.
     if let Some(path) = find_mcp_binary() {
-        McpCommand {
+        return McpCommand {
             command: path,
             args: vec![],
-        }
-    } else {
-        McpCommand {
-            command: "npx".to_string(),
-            args: vec!["-y".to_string(), "phantom-secrets-mcp".to_string()],
-        }
+        };
+    }
+
+    // (3) Last resort: npx wrapper.
+    McpCommand {
+        command: "npx".to_string(),
+        args: vec!["-y".to_string(), "phantom-secrets-mcp".to_string()],
     }
 }
 

--- a/crates/phantom-cli/src/main.rs
+++ b/crates/phantom-cli/src/main.rs
@@ -13,7 +13,7 @@ use tracing_subscriber::EnvFilter;
                   A local proxy intercepts API calls, swaps in real credentials at the network layer.\n\
                   The AI agent never sees a real secret.\n\n\
                   Commands are grouped (in display order):\n  \
-                    Setup        init · setup · doctor · completion\n  \
+                    Setup        init · setup · doctor · completion · mcp\n  \
                     Daily use    exec · start · stop · status · check · list · add · remove · reveal · copy · env · why\n  \
                     Sync & teams login · logout · cloud · team · sync · pull · export · import · wrap · unwrap\n  \
                     Maintenance  upgrade · watch · rotate · open · audit",
@@ -89,6 +89,13 @@ enum Commands {
         /// Shell to generate completions for
         #[arg(value_enum)]
         shell: clap_complete::Shell,
+    },
+
+    /// MCP server commands (Model Context Protocol)
+    #[command(next_help_heading = "Setup")]
+    Mcp {
+        #[command(subcommand)]
+        action: McpAction,
     },
 
     // ─────────────────────────── Daily use ───────────────────────────
@@ -381,6 +388,12 @@ enum Commands {
 }
 
 #[derive(Subcommand)]
+enum McpAction {
+    /// Run the MCP stdio server in-process (used by AI clients like Claude Code)
+    Serve,
+}
+
+#[derive(Subcommand)]
 enum TeamAction {
     /// List your teams
     List,
@@ -555,6 +568,9 @@ fn main() -> anyhow::Result<()> {
         Commands::Open { target } => commands::open::run(&target),
         Commands::Upgrade { force, check_only } => commands::upgrade::run(force, check_only),
         Commands::Completion { shell } => commands::completion::run(shell),
+        Commands::Mcp { action } => match action {
+            McpAction::Serve => commands::mcp::run_serve(),
+        },
         Commands::ClearClipboardAfter { secs } => commands::reveal::run_clear_after(secs),
         Commands::Team { action } => match action {
             TeamAction::List => commands::team::run_list(),

--- a/crates/phantom-mcp/Cargo.toml
+++ b/crates/phantom-mcp/Cargo.toml
@@ -11,6 +11,10 @@ description = "MCP server for Phantom Secrets — lets AI tools manage secrets s
 keywords = ["mcp", "mcp-server", "secrets", "ai-safety", "claude"]
 categories = ["development-tools", "command-line-utilities"]
 
+[lib]
+name = "phantom_mcp"
+path = "src/lib.rs"
+
 [[bin]]
 name = "phantom-mcp"
 path = "src/main.rs"

--- a/crates/phantom-mcp/src/lib.rs
+++ b/crates/phantom-mcp/src/lib.rs
@@ -1,0 +1,37 @@
+mod server;
+mod tools;
+
+use rmcp::transport::stdio;
+use rmcp::ServiceExt;
+
+/// Install a tracing subscriber suitable for MCP stdio servers (logs to stderr,
+/// no ANSI, no timestamps). Safe to call when no subscriber has been set yet.
+///
+/// When embedded inside `phantom mcp serve` the CLI already owns the global
+/// subscriber, so we skip re-initialisation — the existing subscriber is fine
+/// because it also writes to stderr and leaves stdout clean for JSON-RPC.
+pub fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .with_target(false)
+        .try_init();
+}
+
+/// Run the Phantom MCP stdio server until the transport closes.
+///
+/// This is the main entry-point used both by the standalone `phantom-mcp`
+/// binary and by `phantom mcp serve` inside the main `phantom` CLI.
+pub async fn run_stdio_server() -> anyhow::Result<()> {
+    init_tracing();
+
+    tracing::info!("Phantom MCP server starting...");
+
+    let server = server::PhantomMcpServer::new()?;
+
+    let service = server.serve(stdio()).await?;
+
+    service.waiting().await?;
+
+    Ok(())
+}

--- a/crates/phantom-mcp/src/main.rs
+++ b/crates/phantom-mcp/src/main.rs
@@ -1,25 +1,4 @@
-mod server;
-mod tools;
-
-use rmcp::transport::stdio;
-use rmcp::ServiceExt;
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // MCP servers MUST log to stderr, never stdout (stdout is the JSON-RPC transport)
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_ansi(false)
-        .with_target(false)
-        .init();
-
-    tracing::info!("Phantom MCP server starting...");
-
-    let server = server::PhantomMcpServer::new()?;
-
-    let service = server.serve(stdio()).await?;
-
-    service.waiting().await?;
-
-    Ok(())
+    phantom_mcp::run_stdio_server().await
 }


### PR DESCRIPTION
## Summary

- **New subcommand**: `phantom mcp serve` runs the MCP stdio server in-process — no separate binary needed.
- **Dual-target `phantom-mcp` crate**: added `src/lib.rs` exposing `pub async fn run_stdio_server()`. The standalone `phantom-mcp` binary becomes a thin shim that calls the lib. Backward-compatible.
- **`phantom setup` now prefers bundled path**: `mcp_command_spec` resolution order is now (1) current exe + `["mcp", "serve"]`, (2) `phantom-mcp` on PATH, (3) `npx -y phantom-secrets-mcp`. Running `phantom setup --client claude` writes `command: "/path/to/phantom", args: ["mcp", "serve"]`.
- **`try_init()` for tracing**: avoids double-subscriber panic when the lib is embedded inside the CLI (which already installed its own global subscriber).

## Test plan

- [ ] `cargo build --workspace` — clean
- [ ] `cargo test --workspace` — all pass
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [ ] `cargo fmt --all -- --check` — no diffs
- [ ] `echo '{"jsonrpc":"2.0","id":1,...}' | phantom mcp serve` — responds with MCP initialize result on stdout
- [ ] `phantom setup --client claude --print` — shows `command: "<path>/phantom", args: ["mcp", "serve"]`
- [ ] `phantom mcp --help` shows `serve` subcommand
- [ ] `phantom --help` shows `mcp` in the Setup group

🤖 Generated with [Claude Code](https://claude.com/claude-code)